### PR TITLE
Enhance settings page

### DIFF
--- a/apps/web/src/lib/theme.tsx
+++ b/apps/web/src/lib/theme.tsx
@@ -1,0 +1,58 @@
+import { type ParentProps, createContext, createSignal, onMount, useContext } from "solid-js"
+
+export type Theme = "light" | "dark"
+
+interface ThemeContextValue {
+	theme: () => Theme
+	setTheme: (theme: Theme) => void
+	toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextValue>()
+
+export function applyInitialTheme() {
+	if (typeof window === "undefined") return
+	const stored = localStorage.getItem("theme") as Theme | null
+	const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches
+	const initial = stored ?? (prefersDark ? "dark" : "light")
+	document.body.classList.toggle("dark", initial === "dark")
+}
+
+export const ThemeProvider = (props: ParentProps) => {
+	const [theme, setTheme] = createSignal<Theme>("light")
+
+	onMount(() => {
+		if (typeof window === "undefined") return
+		const stored = localStorage.getItem("theme") as Theme | null
+		const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches
+		const initial = stored ?? (prefersDark ? "dark" : "light")
+		setTheme(initial)
+		document.body.classList.toggle("dark", initial === "dark")
+	})
+
+	const applyTheme = (next: Theme) => {
+		setTheme(next)
+		if (typeof window !== "undefined") {
+			document.body.classList.toggle("dark", next === "dark")
+			localStorage.setItem("theme", next)
+		}
+	}
+
+	const toggleTheme = () => {
+		applyTheme(theme() === "dark" ? "light" : "dark")
+	}
+
+	const ctx: ThemeContextValue = {
+		theme,
+		setTheme: applyTheme,
+		toggleTheme,
+	}
+
+	return <ThemeContext.Provider value={ctx}>{props.children}</ThemeContext.Provider>
+}
+
+export function useTheme() {
+	const ctx = useContext(ThemeContext)
+	if (!ctx) throw new Error("useTheme must be used within a ThemeProvider")
+	return ctx
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -15,6 +15,9 @@ import { Toaster } from "./components/ui/toaster"
 import { ConvexSolidClient } from "./lib/convex"
 import { ConvexProviderWithClerk } from "./lib/convex-clerk"
 import { NotificationManager } from "./lib/notification-manager"
+import { ThemeProvider, applyInitialTheme } from "./lib/theme"
+
+applyInitialTheme()
 
 const router = createRouter({
 	routeTree,
@@ -51,17 +54,19 @@ const InnerProviders = () => {
 
 function App() {
 	return (
-		<ClerkProvider publishableKey={import.meta.env.VITE_CLERK_PUBLISHABLE_KEY}>
-			<Suspense>
-				<ConvexProviderWithClerk client={convex} useAuth={useAuth}>
-					<Toaster />
-					<InnerProviders />
-					<Show when={import.meta.env.DEV}>
-						<FpsCounter />
-					</Show>
-				</ConvexProviderWithClerk>
-			</Suspense>
-		</ClerkProvider>
+		<ThemeProvider>
+			<ClerkProvider publishableKey={import.meta.env.VITE_CLERK_PUBLISHABLE_KEY}>
+				<Suspense>
+					<ConvexProviderWithClerk client={convex} useAuth={useAuth}>
+						<Toaster />
+						<InnerProviders />
+						<Show when={import.meta.env.DEV}>
+							<FpsCounter />
+						</Show>
+					</ConvexProviderWithClerk>
+				</Suspense>
+			</ClerkProvider>
+		</ThemeProvider>
 	)
 }
 

--- a/apps/web/src/routes/_protected/_app/$serverId/settings.tsx
+++ b/apps/web/src/routes/_protected/_app/$serverId/settings.tsx
@@ -1,9 +1,11 @@
 import { api } from "@hazel/backend/api"
 import { createFileRoute } from "@tanstack/solid-router"
-import { Show } from "solid-js"
+import { Show, createSignal } from "solid-js"
 import { Button } from "~/components/ui/button"
 import { Card } from "~/components/ui/card"
+import { SelectNative } from "~/components/ui/select-native"
 import { createQuery } from "~/lib/convex"
+import { useTheme } from "~/lib/theme"
 
 export const Route = createFileRoute("/_protected/_app/$serverId/settings")({
 	component: RouteComponent,
@@ -11,42 +13,104 @@ export const Route = createFileRoute("/_protected/_app/$serverId/settings")({
 
 function RouteComponent() {
 	const notificationStatus = createQuery(api.expo.getStatusForUser)
+	const [showOnline, setShowOnline] = createSignal(true)
+	const [videoEnabled, setVideoEnabled] = createSignal(false)
+	const [callingEnabled, setCallingEnabled] = createSignal(false)
+	const { theme, setTheme } = useTheme()
 
 	return (
-		<div>
+		<div class="space-y-4">
 			<Card>
 				<Card.Header>
 					<Card.Title>Notifications</Card.Title>
 				</Card.Header>
-				<Card.Content>
+				<Card.Content class="space-y-2">
 					<Show when={notificationStatus()} keyed>
 						{(status) => (
 							<>
-								<div class="flex grid-rows-subgrid flex-col gap-2">
-									<div class="flex items-center gap-2">
-										<div class="text-muted-foreground text-sm">
-											{status.paused ? "Paused" : "Active"}
-										</div>
-										<Button
-										// onClick={() => api.expo.pauseNotificationsForUser({})}
-										>
-											{status.paused ? "Resume" : "Pause"}
-										</Button>
-									</div>
-									<div class="flex items-center gap-2">
-										<div class="text-muted-foreground text-sm">
-											{status.hasToken ? "Registered" : "Not Registered"}
-										</div>
-										<Button
-										// onClick={() => api.expo.recordPushNotificationToken({})}
-										>
-											{status.hasToken ? "Unregister" : "Register"}
-										</Button>
-									</div>
+								<div class="flex items-center justify-between">
+									<span class="text-muted-foreground text-sm">
+										{status.paused ? "Paused" : "Active"}
+									</span>
+									<Button
+										onClick={() => api.expo.pauseNotificationsForUser({})}
+										size="small"
+									>
+										{status.paused ? "Resume" : "Pause"}
+									</Button>
+								</div>
+								<div class="flex items-center justify-between">
+									<span class="text-muted-foreground text-sm">
+										{status.hasToken ? "Registered" : "Not Registered"}
+									</span>
+									<Button
+										onClick={() => api.expo.recordPushNotificationToken({})}
+										size="small"
+									>
+										{status.hasToken ? "Unregister" : "Register"}
+									</Button>
 								</div>
 							</>
 						)}
 					</Show>
+				</Card.Content>
+			</Card>
+			<Card>
+				<Card.Header>
+					<Card.Title>Appearance</Card.Title>
+				</Card.Header>
+				<Card.Content class="max-w-xs">
+					<SelectNative
+						label="Theme"
+						value={theme()}
+						onInput={(e) => setTheme(e.currentTarget.value as any)}
+					>
+						<option value="light">Light</option>
+						<option value="dark">Dark</option>
+					</SelectNative>
+				</Card.Content>
+			</Card>
+			<Card>
+				<Card.Header>
+					<Card.Title>Privacy</Card.Title>
+				</Card.Header>
+				<Card.Content>
+					<label class="flex items-center justify-between gap-2">
+						<span>Show Online Status</span>
+						<input
+							type="checkbox"
+							checked={showOnline()}
+							onChange={() => setShowOnline(!showOnline())}
+							class="size-4"
+						/>
+					</label>
+				</Card.Content>
+			</Card>
+			<Card>
+				<Card.Header>
+					<Card.Title>Voice &amp; Video</Card.Title>
+				</Card.Header>
+				<Card.Content class="space-y-2">
+					<label class="flex items-center justify-between gap-2">
+						<span>Enable Video Chat (Coming Soon)</span>
+						<input
+							type="checkbox"
+							checked={videoEnabled()}
+							onChange={() => setVideoEnabled(!videoEnabled())}
+							disabled
+							class="size-4"
+						/>
+					</label>
+					<label class="flex items-center justify-between gap-2">
+						<span>Enable Voice Calls (Coming Soon)</span>
+						<input
+							type="checkbox"
+							checked={callingEnabled()}
+							onChange={() => setCallingEnabled(!callingEnabled())}
+							disabled
+							class="size-4"
+						/>
+					</label>
 				</Card.Content>
 			</Card>
 		</div>


### PR DESCRIPTION
## Summary
- add ThemeProvider with context and hooks
- apply stored theme on startup and wrap app with provider
- pretty up settings page using built-in components

## Testing
- `npx biome check apps/web/src/main.tsx apps/web/src/lib/theme.tsx apps/web/src/routes/_protected/_app/$serverId/settings.tsx`
- `npx vitest run` *(fails: ENOENT & missing jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68406ae27ba48326a16b2bf2ca4dd76e