### PR TITLE
Improve message paging

### DIFF
--- a/apps/web/src/lib/convex/create-cached-paginated.tsx
+++ b/apps/web/src/lib/convex/create-cached-paginated.tsx
@@ -1,50 +1,53 @@
-import { createEffect, createMemo, createSignal } from "solid-js"
+import { createEffect, createMemo, createSignal, onCleanup } from "solid-js"
 import {
-  createPaginatedQuery,
-  type PaginatedQueryArgs,
-  type PaginatedQueryItem,
-  type PaginatedQueryReference,
-  type CreatePaginatedQueryReturnType,
+	type CreatePaginatedQueryReturnType,
+	type PaginatedQueryArgs,
+	type PaginatedQueryItem,
+	type PaginatedQueryReference,
+	createPaginatedQuery,
 } from "./create-paginated"
 
 export function createCachedPaginatedQuery<Query extends PaginatedQueryReference>(
-  query: Query,
-  args: PaginatedQueryArgs<Query> | "skip",
-  options: { initialNumItems: number },
-  cacheKey: string,
+	query: Query,
+	args: PaginatedQueryArgs<Query> | "skip",
+	options: { initialNumItems: number },
+	cacheKey: string,
 ): CreatePaginatedQueryReturnType<Query> {
-  const [cached, setCached] = createSignal<PaginatedQueryItem<Query>[]>([])
+	const [cached, setCached] = createSignal<PaginatedQueryItem<Query>[]>([])
 
-  createEffect(() => {
-    try {
-      const raw = localStorage.getItem(cacheKey)
-      setCached(raw ? (JSON.parse(raw) as PaginatedQueryItem<Query>[]) : [])
-    } catch {
-      setCached([])
-    }
-  })
+	createEffect(() => {
+		const id = setTimeout(() => {
+			try {
+				const raw = localStorage.getItem(cacheKey)
+				setCached(raw ? (JSON.parse(raw) as PaginatedQueryItem<Query>[]) : [])
+			} catch {
+				setCached([])
+			}
+		})
+		onCleanup(() => clearTimeout(id))
+	})
 
-  const paginated = createPaginatedQuery(query, args as PaginatedQueryArgs<Query>, options)
+	const paginated = createPaginatedQuery(query, args as PaginatedQueryArgs<Query>, options)
 
-  createEffect(() => {
-    const results = paginated.results()
-    if (results.length > 0) {
-      setCached(results as PaginatedQueryItem<Query>[])
-      try {
-        localStorage.setItem(cacheKey, JSON.stringify(results))
-      } catch {
-        /* ignore */
-      }
-    }
-  })
+	createEffect(() => {
+		const results = paginated.results()
+		if (results.length > 0) {
+			setCached(results as PaginatedQueryItem<Query>[])
+			try {
+				localStorage.setItem(cacheKey, JSON.stringify(results))
+			} catch {
+				/* ignore */
+			}
+		}
+	})
 
-  const combinedResults = createMemo(() => {
-    const res = paginated.results()
-    return res.length > 0 ? res : cached()
-  })
+	const combinedResults = createMemo(() => {
+		const res = paginated.results()
+		return res.length > 0 ? res : cached()
+	})
 
-  return {
-    ...paginated,
-    results: combinedResults,
-  } as CreatePaginatedQueryReturnType<Query>
+	return {
+		...paginated,
+		results: combinedResults,
+	} as CreatePaginatedQueryReturnType<Query>
 }


### PR DESCRIPTION
## Summary
- optimize localStorage reading in cached pagination
- reset pagination ID when channel mounts
- keep build passing

## Testing
- `bun x biome check apps/web/src/lib/convex/create-cached-paginated.tsx apps/web/src/routes/_protected/_app/$serverId/chat/-components/channel.tsx`
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_e_6840b5a1f0d88326a9f80bf64ba359e7