### PR TITLE
Configure vitest workspace

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,32 +1,33 @@
 {
-	"name": "@hazel/backend",
-	"version": "1.0.0",
-	"description": "",
-	"scripts": {
-		"dev": "convex dev",
-		"setup": "convex dev --until-success",
-		"convex:deploy": "npx convex deploy --cmd-url-env-var-name VITE_CONVEX_URL --cmd='cd ../web && bun run build' "
-	},
-	"dependencies": {
-		"convex": "^1.24.6",
-		"convex-test": "^0.0.37"
-	},
-	"devDependencies": {
-		"typescript": "5.8.3",
-		"vitest": "^3.2.0"
-	},
-	"exports": {
-		".": {
-			"types": "./convex/_generated/dataModel.d.ts"
-		},
-		"./api": {
-			"import": "./convex/_generated/api.js",
-			"types": "./convex/_generated/api.d.ts"
-		},
-		"./server": {
-			"import": "./convex/_generated/server.js",
-			"types": "./convex/_generated/server.d.ts"
-		},
-		"./schema": "./convex/schema.ts"
-	}
+  "name": "@hazel/backend",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "dev": "convex dev",
+    "setup": "convex dev --until-success",
+    "convex:deploy": "npx convex deploy --cmd-url-env-var-name VITE_CONVEX_URL --cmd='cd ../web && bun run build' ",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "convex": "^1.24.6",
+    "convex-test": "^0.0.37"
+  },
+  "devDependencies": {
+    "typescript": "5.8.3",
+    "vitest": "^3.2.0"
+  },
+  "exports": {
+    ".": {
+      "types": "./convex/_generated/dataModel.d.ts"
+    },
+    "./api": {
+      "import": "./convex/_generated/api.js",
+      "types": "./convex/_generated/api.d.ts"
+    },
+    "./server": {
+      "import": "./convex/_generated/server.js",
+      "types": "./convex/_generated/server.d.ts"
+    },
+    "./schema": "./convex/schema.ts"
+  }
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+  },
+})

--- a/package.json
+++ b/package.json
@@ -1,26 +1,32 @@
 {
-	"name": "maki-chat",
-	"private": true,
-	"packageManager": "bun@1.2.11",
-	"workspaces": {
-		"packages": ["apps/*", "packages/*"]
-	},
-	"scripts": {
-		"dev": "turbo dev",
-		"build": "turbo build typecheck",
-		"typecheck": "turbo build typecheck",
-		"setup:dev": "bun run ./scripts/setup-dev.ts",
-		"dev:zero-cache": "zero-cache-dev -p ./packages/zero/src/schema.ts",
-		"dev:db-up": "docker compose --env-file .env -f ./docker/docker-compose.yml up -d",
-		"dev:db-down": "docker compose --env-file .env -f ./docker/docker-compose.yml down",
-		"dev:clean": "source .env && docker volume rm -f maki-chat_pgdata && rm -rf \"${ZERO_REPLICA_FILE}\"*"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "^1.9.4"
-	},
-	"trustedDependencies": ["@rocicorp/zero-sqlite3"],
-	"dependencies": {
-		"@effect/sql-pg": "^0.36.7",
-		"turbo": "^2.5.3"
-	}
+  "name": "maki-chat",
+  "private": true,
+  "packageManager": "bun@1.2.11",
+  "workspaces": {
+    "packages": [
+      "apps/*",
+      "packages/*"
+    ]
+  },
+  "scripts": {
+    "dev": "turbo dev",
+    "build": "turbo build typecheck",
+    "typecheck": "turbo build typecheck",
+    "setup:dev": "bun run ./scripts/setup-dev.ts",
+    "dev:zero-cache": "zero-cache-dev -p ./packages/zero/src/schema.ts",
+    "dev:db-up": "docker compose --env-file .env -f ./docker/docker-compose.yml up -d",
+    "dev:db-down": "docker compose --env-file .env -f ./docker/docker-compose.yml down",
+    "dev:clean": "source .env && docker volume rm -f maki-chat_pgdata && rm -rf \"${ZERO_REPLICA_FILE}\"*",
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4"
+  },
+  "trustedDependencies": [
+    "@rocicorp/zero-sqlite3"
+  ],
+  "dependencies": {
+    "@effect/sql-pg": "^0.36.7",
+    "turbo": "^2.5.3"
+  }
 }

--- a/packages/markdown/vitest.config.ts
+++ b/packages/markdown/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+  },
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  projects: [
+    './apps/backend',
+    './apps/web',
+    './packages/markdown',
+  ],
+})


### PR DESCRIPTION
## Summary
- add test script in backend
- add root Vitest script and workspace config
- set up jsdom testing configs for the web and markdown packages

## Testing
- `bun x vitest run`
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_6840b6d40c648326b63aaad142230c34