### PR TITLE
Fix Add Server button

### DIFF
--- a/apps/web/src/routes/_protected/_app/$serverId/-components/create-server-dialog.tsx
+++ b/apps/web/src/routes/_protected/_app/$serverId/-components/create-server-dialog.tsx
@@ -1,0 +1,71 @@
+import { DialogCloseTrigger } from "@ark-ui/solid"
+import { api } from "@hazel/backend/api"
+import { useNavigate } from "@tanstack/solid-router"
+
+import { Button } from "~/components/ui/button"
+import { Dialog } from "~/components/ui/dialog"
+import { TextField } from "~/components/ui/text-field"
+import { toaster } from "~/components/ui/toaster"
+import { createMutation } from "~/lib/convex"
+
+export interface CreateServerDialogProps {
+	open: boolean
+	onOpenChange: (open: boolean) => void
+}
+
+export const CreateServerDialog = (props: CreateServerDialogProps) => {
+	const navigate = useNavigate()
+	const createServer = createMutation(api.servers.createServer)
+
+	return (
+		<Dialog open={props.open} onOpenChange={(details) => props.onOpenChange(details.open)}>
+			<Dialog.Content>
+				<Dialog.Header>
+					<Dialog.Title>Create a Server</Dialog.Title>
+					<Dialog.Description>Enter a name for your new server.</Dialog.Description>
+				</Dialog.Header>
+				<form
+					class="flex flex-col gap-4"
+					onSubmit={async (e) => {
+						e.preventDefault()
+						const formData = new FormData(e.currentTarget)
+						const serverName = formData.get("serverName")
+
+						if (!serverName) return
+						try {
+							const serverId = await createServer({
+								name: serverName.toString(),
+							})
+							props.onOpenChange(false)
+							navigate({ to: "/$serverId", params: { serverId } })
+						} catch (error) {
+							console.error("Failed to create server:", error)
+							toaster.error({
+								title: "Failed to create server",
+								description: "Failed to create server. Please try again.",
+								type: "error",
+							})
+						}
+					}}
+				>
+					<TextField
+						label="Server Name"
+						name="serverName"
+						required
+						placeholder="Enter your server name"
+					/>
+					<Dialog.Footer class="justify-between!">
+						<DialogCloseTrigger
+							asChild={(props) => (
+								<Button type="button" intent="outline" {...props}>
+									Cancel
+								</Button>
+							)}
+						/>
+						<Button type="submit">Create Server</Button>
+					</Dialog.Footer>
+				</form>
+			</Dialog.Content>
+		</Dialog>
+	)
+}

--- a/apps/web/src/routes/_protected/_app/$serverId/-components/workspace-switcher.tsx
+++ b/apps/web/src/routes/_protected/_app/$serverId/-components/workspace-switcher.tsx
@@ -1,83 +1,93 @@
 import { api } from "@hazel/backend/api"
 import { Link, useParams } from "@tanstack/solid-router"
-import { For, createMemo } from "solid-js"
+import { For, createMemo, createSignal } from "solid-js"
 import { IconChevronUpDown } from "~/components/icons/chevron-up-down"
 import { IconPlus } from "~/components/icons/plus"
 import { Avatar } from "~/components/ui/avatar"
 import { Menu } from "~/components/ui/menu"
 import { Sidebar } from "~/components/ui/sidebar"
 import { createQuery } from "~/lib/convex"
+import { CreateServerDialog } from "./create-server-dialog"
 
 export const WorkspaceSwitcher = () => {
 	const params = useParams({
 		from: "/_protected/_app/$serverId",
 	})
 
+	const [createDialogOpen, setCreateDialogOpen] = createSignal(false)
+
 	const servers = createQuery(api.servers.getServersForUser)
 
 	const activeServer = createMemo(() => servers()?.find((server) => server._id === params().serverId))
 
 	return (
-		<Sidebar.Menu>
-			<Sidebar.MenuItem>
-				<Menu>
-					<Menu.Trigger
-						asChild={(props) => (
-							<Sidebar.MenuButton
-								size="lg"
-								class="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
-								{...props()}
-							>
-								<Avatar
-									size="xs"
-									src={activeServer()?.imageUrl}
-									name={activeServer()?.name!}
-								/>
-								<div class="grid flex-1 text-left text-sm leading-tight">
-									<span class="truncate font-semibold">{activeServer()?.name}</span>
-								</div>
-								<IconChevronUpDown class="ml-auto" />
-							</Sidebar.MenuButton>
-						)}
-					/>
-					<Menu.Content class="min-w-56 rounded-lg">
-						<Menu.ItemGroup>
-							<Menu.Label>Servers</Menu.Label>
-							<For each={servers()}>
-								{(server) => (
-									<Menu.Item
-										class="flex items-center gap-2"
-										value={server._id}
-										asChild={(props) => (
-											<Link
-												to="/$serverId"
-												params={{
-													serverId: server._id,
-												}}
-												{...props()}
-											/>
-										)}
-									>
-										<Avatar size="xs" src={server.imageUrl} name={server.name} />
-										<span class="truncate text-muted-foreground text-xs">
-											{server.name}
-										</span>
-									</Menu.Item>
-								)}
-							</For>
-						</Menu.ItemGroup>
-						<Menu.Separator />
-						<Menu.ItemGroup>
-							<Menu.Item value="add-server" class="gap-2 p-2">
-								<div class="flex size-6 items-center justify-center rounded-md border bg-background">
-									<IconPlus class="size-4" />
-								</div>
-								<div class="font-medium text-muted-foreground">Add Server</div>
-							</Menu.Item>
-						</Menu.ItemGroup>
-					</Menu.Content>
-				</Menu>
-			</Sidebar.MenuItem>
-		</Sidebar.Menu>
+		<>
+			<Sidebar.Menu>
+				<Sidebar.MenuItem>
+					<Menu>
+						<Menu.Trigger
+							asChild={(props) => (
+								<Sidebar.MenuButton
+									size="lg"
+									class="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+									{...props()}
+								>
+									<Avatar
+										size="xs"
+										src={activeServer()?.imageUrl}
+										name={activeServer()?.name!}
+									/>
+									<div class="grid flex-1 text-left text-sm leading-tight">
+										<span class="truncate font-semibold">{activeServer()?.name}</span>
+									</div>
+									<IconChevronUpDown class="ml-auto" />
+								</Sidebar.MenuButton>
+							)}
+						/>
+						<Menu.Content class="min-w-56 rounded-lg">
+							<Menu.ItemGroup>
+								<Menu.Label>Servers</Menu.Label>
+								<For each={servers()}>
+									{(server) => (
+										<Menu.Item
+											class="flex items-center gap-2"
+											value={server._id}
+											asChild={(props) => (
+												<Link
+													to="/$serverId"
+													params={{
+														serverId: server._id,
+													}}
+													{...props()}
+												/>
+											)}
+										>
+											<Avatar size="xs" src={server.imageUrl} name={server.name} />
+											<span class="truncate text-muted-foreground text-xs">
+												{server.name}
+											</span>
+										</Menu.Item>
+									)}
+								</For>
+							</Menu.ItemGroup>
+							<Menu.Separator />
+							<Menu.ItemGroup>
+								<Menu.Item
+									value="add-server"
+									class="gap-2 p-2"
+									onSelect={() => setCreateDialogOpen(true)}
+								>
+									<div class="flex size-6 items-center justify-center rounded-md border bg-background">
+										<IconPlus class="size-4" />
+									</div>
+									<div class="font-medium text-muted-foreground">Add Server</div>
+								</Menu.Item>
+							</Menu.ItemGroup>
+						</Menu.Content>
+					</Menu>
+				</Sidebar.MenuItem>
+			</Sidebar.Menu>
+			<CreateServerDialog open={createDialogOpen()} onOpenChange={setCreateDialogOpen} />
+		</>
 	)
 }


### PR DESCRIPTION
## Summary
- open a create-server dialog instead of redirecting to onboarding
- add `CreateServerDialog` component for server creation

## Testing
- `bun run format:fix`
- `bun run test:once`


------
https://chatgpt.com/codex/tasks/task_e_6841ad8f1f24832689e1d552b5ac71ff