### PR TITLE
Implement optimistic reactions

### DIFF
--- a/apps/web/src/components/chat-ui/message/reaction-tags.tsx
+++ b/apps/web/src/components/chat-ui/message/reaction-tags.tsx
@@ -1,4 +1,4 @@
-import type { Doc } from "@hazel/backend"
+import type { Doc, Id } from "@hazel/backend"
 import { api } from "@hazel/backend/api"
 import { useQuery } from "@tanstack/solid-query"
 import { useAuth } from "clerk-solidjs"
@@ -7,7 +7,11 @@ import { useChat } from "~/components/chat-state/chat-store"
 import { IconEmojiAdd } from "~/components/icons/emoji-add"
 import { Button } from "~/components/ui/button"
 import { Popover } from "~/components/ui/popover"
-import { createMutation } from "~/lib/convex"
+import {
+       createMutation,
+       optimisticAddReaction,
+       optimisticRemoveReaction,
+} from "~/lib/convex"
 import { convexQuery } from "~/lib/convex-query"
 import { EmojiPicker } from "./emoji-picker"
 
@@ -42,8 +46,33 @@ export function ReactionTags(props: ReactionTagsProps) {
 		return props.message().reactions.filter((reaction) => reaction.userId === meQuery.data?._id)
 	})
 
-	const removeReaction = createMutation(api.messages.deleteReaction)
-	const addReaction = createMutation(api.messages.createReaction)
+       const removeReaction = createMutation(api.messages.deleteReaction).withOptimisticUpdate(
+               (store, args) => {
+                       const userId = meQuery.data?._id
+                       if (!userId) return
+                       optimisticRemoveReaction(store, {
+                               serverId: args.serverId as Id<"servers">,
+                               channelId: props.message().channelId as Id<"channels">,
+                               messageId: args.id as Id<"messages">,
+                               emoji: args.emoji,
+                               userId,
+                       })
+               },
+       )
+
+       const addReaction = createMutation(api.messages.createReaction).withOptimisticUpdate(
+               (store, args) => {
+                       const userId = meQuery.data?._id
+                       if (!userId) return
+                       optimisticAddReaction(store, {
+                               serverId: args.serverId as Id<"servers">,
+                               channelId: props.message().channelId as Id<"channels">,
+                               messageId: args.messageId as Id<"messages">,
+                               emoji: args.emoji,
+                               userId,
+                       })
+               },
+       )
 
 	async function createReaction(emoji: string) {
 		if (!meQuery.data) return

--- a/apps/web/src/lib/convex/index.ts
+++ b/apps/web/src/lib/convex/index.ts
@@ -2,3 +2,5 @@ export * from "./client"
 
 export * from "./create-paginated"
 export * from "./create-cached-paginated"
+
+export * from "./optimistic"

--- a/apps/web/src/lib/convex/optimistic.ts
+++ b/apps/web/src/lib/convex/optimistic.ts
@@ -1,0 +1,78 @@
+import type { Doc, Id } from "@hazel/backend"
+import { api } from "@hazel/backend/api"
+import type { OptimisticLocalStore } from "convex/browser"
+import { optimisticallyUpdateValueInPaginatedQuery } from "./create-paginated"
+
+export function optimisticAddReaction(
+  store: OptimisticLocalStore,
+  args: {
+    serverId: Id<"servers">
+    channelId: Id<"channels">
+    messageId: Id<"messages">
+    emoji: string
+    userId: string
+  },
+) {
+  const update = (msg: Doc<"messages">) => ({
+    ...msg,
+    reactions: [...msg.reactions, { userId: args.userId, emoji: args.emoji }],
+  })
+
+  optimisticallyUpdateValueInPaginatedQuery(
+    store,
+    api.messages.getMessages,
+    { channelId: args.channelId, serverId: args.serverId },
+    (m) => (m._id === args.messageId ? update(m) : m),
+  )
+
+  const current = store.getQuery(api.messages.getMessage, {
+    id: args.messageId,
+    channelId: args.channelId,
+    serverId: args.serverId,
+  })
+  if (current) {
+    store.setQuery(
+      api.messages.getMessage,
+      { id: args.messageId, channelId: args.channelId, serverId: args.serverId },
+      update(current),
+    )
+  }
+}
+
+export function optimisticRemoveReaction(
+  store: OptimisticLocalStore,
+  args: {
+    serverId: Id<"servers">
+    channelId: Id<"channels">
+    messageId: Id<"messages">
+    emoji: string
+    userId: string
+  },
+) {
+  const update = (msg: Doc<"messages">) => ({
+    ...msg,
+    reactions: msg.reactions.filter(
+      (r) => !(r.userId === args.userId && r.emoji === args.emoji),
+    ),
+  })
+
+  optimisticallyUpdateValueInPaginatedQuery(
+    store,
+    api.messages.getMessages,
+    { channelId: args.channelId, serverId: args.serverId },
+    (m) => (m._id === args.messageId ? update(m) : m),
+  )
+
+  const current = store.getQuery(api.messages.getMessage, {
+    id: args.messageId,
+    channelId: args.channelId,
+    serverId: args.serverId,
+  })
+  if (current) {
+    store.setQuery(
+      api.messages.getMessage,
+      { id: args.messageId, channelId: args.channelId, serverId: args.serverId },
+      update(current),
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- add optimistic mutation helpers for message reactions
- optimistically update reactions in `ReactionTags` and `MessageActions`

## Testing
- `bun run test` *(fails: Validator error: Unexpected field `userId` in object)*

------
https://chatgpt.com/codex/tasks/task_e_6855d4bb94348326a93aaab783f84272