### PR TITLE
Improve invite page UI

### DIFF
--- a/apps/web/src/routes/_protected/invite/$code.tsx
+++ b/apps/web/src/routes/_protected/invite/$code.tsx
@@ -4,6 +4,7 @@ import { Show, createSignal } from "solid-js"
 
 import { IconLoader } from "~/components/icons/loader"
 import { Button } from "~/components/ui/button"
+import { Card } from "~/components/ui/card"
 import { toaster } from "~/components/ui/toaster"
 import { createMutation } from "~/lib/convex"
 
@@ -20,35 +21,48 @@ function RouteComponent() {
 	const [status, setStatus] = createSignal<"idle" | "loading" | "error">("idle")
 
 	return (
-		<div class="flex min-h-screen flex-col items-center justify-center gap-4 bg-background p-6 text-foreground">
-			<Show when={status() === "idle"}>
-				<Button
-					disabled={status() === "loading"}
-					onClick={async () => {
-						setStatus("loading")
-						try {
-							const serverId = await acceptInvite({ code: params().code })
-							navigate({ to: "/$serverId" as const, params: { serverId } })
-						} catch (err) {
-							console.error(err)
-							toaster.error({ title: "Failed to join", type: "error" })
-							setStatus("error")
-						}
-					}}
-				>
-					Join Server
-				</Button>
-			</Show>
+		<div class="flex min-h-screen items-center justify-center bg-background p-6 text-foreground">
+			<Card class="w-96 space-y-4">
+				<Card.Header class="space-y-2 text-center">
+					<Card.Title class="font-bold text-2xl">Join Server</Card.Title>
+					<Card.Description>Accept the invitation to become part of this server.</Card.Description>
+				</Card.Header>
+				<Card.Content class="flex flex-col items-center gap-4">
+					<Show when={status() === "idle"}>
+						<Button
+							class="w-full"
+							disabled={status() === "loading"}
+							onClick={async () => {
+								setStatus("loading")
+								try {
+									const serverId = await acceptInvite({ code: params().code })
+									navigate({ to: "/$serverId" as const, params: { serverId } })
+								} catch (err) {
+									console.error(err)
+									toaster.error({ title: "Failed to join", type: "error" })
+									setStatus("error")
+								}
+							}}
+						>
+							Join Server
+						</Button>
+					</Show>
 
-			<Show when={status() === "loading"}>
-				<IconLoader class="size-6 animate-spin" />
-				<p>Joining...</p>
-			</Show>
+					<Show when={status() === "loading"}>
+						<IconLoader class="size-6 animate-spin" />
+						<p>Joining...</p>
+					</Show>
 
-			<Show when={status() === "error"}>
-				<p class="text-destructive">Failed to accept invite.</p>
-				<Button onClick={() => navigate({ to: "/" })}>Go Home</Button>
-			</Show>
+					<Show when={status() === "error"}>
+						<p class="text-destructive">Failed to accept invite.</p>
+					</Show>
+				</Card.Content>
+				<Show when={status() === "error"}>
+					<Card.Footer class="justify-center">
+						<Button onClick={() => navigate({ to: "/" })}>Go Home</Button>
+					</Card.Footer>
+				</Show>
+			</Card>
 		</div>
 	)
 }


### PR DESCRIPTION
## Summary
- style the accept invite page with a card layout

## Testing
- `npm test` *(fails: Component `presence` is not registered)*

------
https://chatgpt.com/codex/tasks/task_e_6855dad6f8f883268c6d0dbaef0c19b1