### PR TITLE
Add user volume controls to call UI

### DIFF
--- a/apps/web/src/lib/hms/use-video-manager.ts
+++ b/apps/web/src/lib/hms/use-video-manager.ts
@@ -2,8 +2,9 @@ import {
 	type HMSAudioTrack,
 	type HMSConfig,
 	HMSReactiveStore,
-	type HMSTrackID,
-	selectAudioTrackByID,
+       type HMSTrackID,
+       selectAudioTrackByID,
+       selectAudioTrackVolume,
 	selectIsConnectedToRoom,
 	selectIsLocalAudioEnabled,
 	selectIsLocalScreenShared,
@@ -35,9 +36,10 @@ export function useCallManager(props: { serverId: Id<"servers"> }) {
 	const [store, setStore] = createStore({
 		peers: hmsStore.getState(selectPeers).map((peer) => {
 			const track = hmsStore.getState(selectVideoTrackByID(peer.videoTrack))
-			const audio = hmsStore.getState(selectAudioTrackByID(peer.audioTrack))
+                        const audio = hmsStore.getState(selectAudioTrackByID(peer.audioTrack))
+                        const volume = hmsStore.getState(selectAudioTrackVolume(peer.audioTrack))
 
-			return { ...peer, track, audio, volume: audio?.volume ?? 100 }
+                        return { ...peer, track, audio, volume: volume ?? 100 }
 		}),
 		isConnected: hmsStore.getState(selectIsConnectedToRoom),
 		local: {
@@ -124,12 +126,13 @@ export function useCallManager(props: { serverId: Id<"servers"> }) {
 
 			setStore("isConnected", !!selectIsConnectedToRoom(store))
 
-			const peers = selectPeers(store).map((peer) => {
-				const track = selectVideoTrackByID(peer.videoTrack)(store)
-				const audio = selectAudioTrackByID(peer.audioTrack)(store)
+                        const peers = selectPeers(store).map((peer) => {
+                                const track = selectVideoTrackByID(peer.videoTrack)(store)
+                                const audio = selectAudioTrackByID(peer.audioTrack)(store)
+                                const volume = selectAudioTrackVolume(peer.audioTrack)(store)
 
-				return { ...peer, track, audio, volume: audio?.volume ?? 100 }
-			})
+                                return { ...peer, track, audio, volume: volume ?? 100 }
+                        })
 
 			setStore("peers", reconcile(peers, { key: "id" }))
 

--- a/apps/web/src/routes/_protected/_app/$serverId/video.tsx
+++ b/apps/web/src/routes/_protected/_app/$serverId/video.tsx
@@ -81,21 +81,23 @@ function RouteComponent() {
 							{(peer) => (
 								<li class="flex items-center gap-2">
 									{peer.name} ({peer.isLocal ? "You" : "Remote"})
-									<Show when={peer.audio}>
-										<Slider.Root
-											class="flex w-24 touch-none select-none items-center"
-											value={[peer.volume]}
-											min={0}
-											max={100}
-											step={1}
-											onValueChange={(e) => setPeerVolume(peer.audio!.id, e.value[0])}
-										>
-											<Slider.Track class="relative h-1 w-full grow rounded-full bg-muted">
-												<Slider.Range class="absolute h-full rounded-full bg-primary" />
-											</Slider.Track>
-											<Slider.Thumb class="block size-3 rounded-full border border-border bg-background" />
-										</Slider.Root>
-									</Show>
+                                                                       <Show when={peer.audio}>
+                                                                              <Slider.Root
+                                                                               class="flex w-24 touch-none select-none items-center"
+                                                                               value={[peer.volume]}
+                                                                               min={0}
+                                                                               max={100}
+                                                                               step={1}
+                                                                               onValueChange={(e) => setPeerVolume(peer.audio!.id, e.value[0])}
+                                                                              >
+                                                                               <Slider.Control class="w-full">
+                                                                                      <Slider.Track class="relative h-1 w-full grow rounded-full bg-muted">
+                                                                                             <Slider.Range class="absolute h-full rounded-full bg-primary" />
+                                                                                      </Slider.Track>
+                                                                                      <Slider.Thumb index={0} class="block size-3 rounded-full border border-border bg-background" />
+                                                                               </Slider.Control>
+                                                                              </Slider.Root>
+                                                                       </Show>
 								</li>
 							)}
 						</For>


### PR DESCRIPTION
## Summary
- add per-peer volume data and setter in call manager
- display volume sliders in call UI

## Testing
- `bun run test:once` *(fails: Validator error)*

------
https://chatgpt.com/codex/tasks/task_e_6855a70e78c88326b7370f3255f0adf5