### PR TITLE
Org Switcher: Path-Based Navigation with Session Update

### DIFF
--- a/apps/web/src/components/chat/message-item.tsx
+++ b/apps/web/src/components/chat/message-item.tsx
@@ -134,6 +134,7 @@ export function MessageItem({
 				<MessageReplySection
 					replyToMessageId={message.replyToMessageId}
 					channelId={message.channelId}
+					organizationId={orgId as Id<"organizations">}
 					onClick={() => {
 						const replyElement = document.getElementById(`message-${message.replyToMessageId}`)
 						if (replyElement) {

--- a/apps/web/src/components/chat/message-reply-section.tsx
+++ b/apps/web/src/components/chat/message-reply-section.tsx
@@ -7,24 +7,17 @@ import { Avatar } from "../base/avatar/avatar"
 interface MessageReplySectionProps {
 	replyToMessageId: Id<"messages">
 	channelId: Id<"channels">
+	organizationId: Id<"organizations">
 	onClick?: () => void
 }
 
-export function MessageReplySection({ replyToMessageId, channelId, onClick }: MessageReplySectionProps) {
-	const { data: organization } = useQuery(convexQuery(api.me.getOrganization, {}))
-	const organizationId = organization?.directive === "success" ? organization.data._id : undefined
-
+export function MessageReplySection({ replyToMessageId, channelId, organizationId, onClick }: MessageReplySectionProps) {
 	const { data: replyMessage, isLoading } = useQuery(
-		convexQuery(
-			api.messages.getMessage,
-			organizationId
-				? {
-						id: replyToMessageId,
-						channelId,
-						organizationId,
-					}
-				: "skip",
-		),
+		convexQuery(api.messages.getMessage, {
+			id: replyToMessageId,
+			channelId,
+			organizationId,
+		}),
 	)
 
 	return (

--- a/apps/web/src/components/chat/reply-indicator.tsx
+++ b/apps/web/src/components/chat/reply-indicator.tsx
@@ -12,22 +12,14 @@ interface ReplyIndicatorProps {
 }
 
 export function ReplyIndicator({ replyToMessageId, onClose }: ReplyIndicatorProps) {
-	const { channelId } = useChat()
-
-	const { data: organization } = useQuery(convexQuery(api.me.getOrganization, {}))
-	const organizationId = organization?.directive === "success" ? organization.data._id : undefined
+	const { channelId, organizationId } = useChat()
 
 	const { data: message, isLoading } = useQuery(
-		convexQuery(
-			api.messages.getMessage,
-			organizationId
-				? {
-						id: replyToMessageId,
-						channelId,
-						organizationId,
-					}
-				: "skip",
-		),
+		convexQuery(api.messages.getMessage, {
+			id: replyToMessageId,
+			channelId,
+			organizationId,
+		}),
 	)
 
 	if (isLoading) {

--- a/apps/web/src/providers/chat-provider.tsx
+++ b/apps/web/src/providers/chat-provider.tsx
@@ -15,6 +15,7 @@ type TypingUsers = TypingUser[]
 
 interface ChatContextValue {
 	channelId: Id<"channels">
+	organizationId: Id<"organizations">
 	channel: Channel | undefined
 	messages: Message[]
 	pinnedMessages: PinnedMessage[] | undefined
@@ -242,6 +243,7 @@ export function ChatProvider({ channelId, organizationId, children }: ChatProvid
 	const contextValue = useMemo<ChatContextValue>(
 		() => ({
 			channelId,
+			organizationId,
 			channel: channelQuery.data,
 			messages,
 			pinnedMessages: pinnedMessagesQuery.data,

--- a/apps/web/src/routes/app/$orgId/settings/team.tsx
+++ b/apps/web/src/routes/app/$orgId/settings/team.tsx
@@ -42,19 +42,22 @@ function RouteComponent() {
 	} | null>(null)
 	const [removeUserId, setRemoveUserId] = useState<Id<"users"> | null>(null)
 
+	const organizationId = orgId as Id<"organizations">
+	
 	const teamMembersQuery = useConvexQuery(api.users.getUsers, {
-		organizationId: orgId as Id<"organizations">,
+		organizationId,
 	})
 	const removeMemberMutation = useConvexMutation(api.organizations.removeMember)
 	const currentUserQuery = useConvexQuery(api.me.get)
-	const organizationQuery = useConvexQuery(api.me.getOrganization)
+	const organizationQuery = useConvexQuery(api.organizations.getOrganizationById, {
+		organizationId,
+	})
 
 	const { isUserOnline } = usePresence()
 
 	const isLoading = teamMembersQuery === undefined
 	const currentUser = currentUserQuery
-	const organization = organizationQuery?.directive === "success" ? organizationQuery.data : null
-	const organizationId = organization?._id
+	const organization = organizationQuery
 
 	const teamMembers =
 		teamMembersQuery?.map((user) => ({
@@ -78,8 +81,6 @@ function RouteComponent() {
 	}
 
 	const handleRemoveUser = async (userId: Id<"users">) => {
-		if (!organizationId) return
-
 		try {
 			await removeMemberMutation({ organizationId, userId })
 			toast.success("Member removed", {
@@ -239,7 +240,7 @@ function RouteComponent() {
 
 			<EmailInviteModal isOpen={showInviteModal} onOpenChange={setShowInviteModal} />
 
-			{changeRoleUser && organizationId && currentUser && (
+			{changeRoleUser && currentUser && (
 				<ChangeRoleModal
 					isOpen={!!changeRoleUser}
 					onOpenChange={(open) => !open && setChangeRoleUser(null)}


### PR DESCRIPTION
The change updates components to consistently use the organizationId from the session rather than fetching it within components. This approach improves consistency in handling organization data and reduces redundant queries for organizationId.

- MessageReplySection, ReplyIndicator, and other components now receive organizationId directly, eliminating unnecessary conditional organization checks.
- The ChatContext now provides organizationId, enabling easier access throughout the chat application.
- Adjustments in API calls streamline the data flow, using the path-based orgId.
- Updates to the team settings route ensure organization details are accessed effectively, aiding in member management functionality.