### PR TITLE
Add support for group DMs in Create DM Dialog

### DIFF
--- a/apps/web/src/components/application/modals/create-dm-modal.tsx
+++ b/apps/web/src/components/application/modals/create-dm-modal.tsx
@@ -3,7 +3,7 @@ import type { Doc, Id } from "@hazel/backend"
 import { api } from "@hazel/backend/api"
 import { useQuery } from "@tanstack/react-query"
 import { useNavigate, useParams } from "@tanstack/react-router"
-import { Mail01, MessageSquare02, Plus } from "@untitledui/icons"
+import { Mail01, MessageSquare02, Plus, UsersPlus } from "@untitledui/icons"
 import { type } from "arktype"
 import { useMemo, useState } from "react"
 import { DialogTrigger as AriaDialogTrigger, Heading as AriaHeading } from "react-aria-components"
@@ -22,7 +22,7 @@ import { useAppForm } from "~/hooks/use-app-form"
 import { cx } from "~/utils/cx"
 
 const dmFormSchema = type({
-	userId: "string",
+	userIds: "string[]",
 })
 
 type DmFormData = typeof dmFormSchema.infer
@@ -34,7 +34,7 @@ interface CreateDmModalProps {
 
 export const CreateDmModal = ({ isOpen, onOpenChange }: CreateDmModalProps) => {
 	const [searchQuery, setSearchQuery] = useState("")
-	const [selectedUser, setSelectedUser] = useState<Doc<"users"> | null>(null)
+	const [selectedUsers, setSelectedUsers] = useState<Doc<"users">[]>([])
 
 	const navigate = useNavigate()
 	const { orgId } = useParams({ from: "/app/$orgId" })
@@ -45,30 +45,43 @@ export const CreateDmModal = ({ isOpen, onOpenChange }: CreateDmModalProps) => {
 		convexQuery(api.social.getFriendsForOrganization, { organizationId })
 	)
 	const createDmChannelMutation = useConvexMutation(api.channels.createDmChannel)
+	const createGroupDmChannelMutation = useConvexMutation(api.channels.createGroupDmChannel)
 
 	const form = useAppForm({
 		defaultValues: {
-			userId: "",
+			userIds: [],
 		} as DmFormData,
 		validators: {
 			onChange: dmFormSchema,
 		},
 		onSubmit: async ({ value }) => {
-			const user = friendsQuery.data?.find((u) => u?._id === value.userId)
-			if (!user) return
+			if (value.userIds.length === 0) return
 
 			try {
-				const channelId = await createDmChannelMutation({
-					userId: value.userId as any,
-					organizationId,
-				})
+				let channelId: Id<"channels">
+				
+				if (value.userIds.length === 1) {
+					// Single DM
+					channelId = await createDmChannelMutation({
+						userId: value.userIds[0] as Id<"users">,
+						organizationId,
+					})
+					const user = friendsQuery.data?.find((u) => u?._id === value.userIds[0])
+					toast.success(`Started conversation with ${user?.firstName}`)
+				} else {
+					// Group DM
+					channelId = await createGroupDmChannelMutation({
+						userIds: value.userIds as Id<"users">[],
+						organizationId,
+					})
+					toast.success(`Created group conversation with ${value.userIds.length} people`)
+				}
 
-				toast.success(`Started conversation with ${user.firstName}`)
 				onOpenChange(false)
 
 				// Reset form
 				form.reset()
-				setSelectedUser(null)
+				setSelectedUsers([])
 				setSearchQuery("")
 
 				// Navigate to the chat
@@ -107,8 +120,22 @@ export const CreateDmModal = ({ isOpen, onOpenChange }: CreateDmModalProps) => {
 		onOpenChange(false)
 		// Reset form and state when closing
 		form.reset()
-		setSelectedUser(null)
+		setSelectedUsers([])
 		setSearchQuery("")
+	}
+	
+	const toggleUserSelection = (user: Doc<"users">) => {
+		const isSelected = selectedUsers.some((u) => u._id === user._id)
+		let newSelection: Doc<"users">[]
+		
+		if (isSelected) {
+			newSelection = selectedUsers.filter((u) => u._id !== user._id)
+		} else {
+			newSelection = [...selectedUsers, user]
+		}
+		
+		setSelectedUsers(newSelection)
+		form.setFieldValue("userIds", newSelection.map((u) => u._id))
 	}
 
 	return (
@@ -139,23 +166,48 @@ export const CreateDmModal = ({ isOpen, onOpenChange }: CreateDmModalProps) => {
 								</div>
 								<div className="z-10 flex flex-col gap-0.5">
 									<AriaHeading slot="title" className="font-semibold text-md text-primary">
-										Start a direct message
+										Start a conversation
 									</AriaHeading>
 									<p className="text-sm text-tertiary">
-										Select a team member to start a conversation
+										Select one or more team members to start a conversation
 									</p>
 								</div>
 							</div>
 							<div className="h-5 w-full" />
 							<div className="flex flex-col gap-4 px-4 sm:px-6">
 								{/* Search Input */}
-								<Input
-									size="md"
-									placeholder="Search team members..."
-									icon={Mail01}
-									value={searchQuery}
-									onChange={setSearchQuery}
-								/>
+								<div className="flex flex-col gap-2">
+									<Input
+										size="md"
+										placeholder="Search team members..."
+										icon={Mail01}
+										value={searchQuery}
+										onChange={setSearchQuery}
+									/>
+									{selectedUsers.length > 0 && (
+										<div className="flex items-center gap-2">
+											<span className="text-sm text-tertiary">
+												{selectedUsers.length} selected
+											</span>
+											<div className="flex -space-x-2">
+												{selectedUsers.slice(0, 3).map((user) => (
+													<Avatar
+														key={user._id}
+														size="xs"
+														src={user.avatarUrl}
+														initials={`${user.firstName?.charAt(0) || ""}${user.lastName?.charAt(0) || ""}`}
+														alt={`${user.firstName || ""} ${user.lastName || ""}`}
+													/>
+												))}
+												{selectedUsers.length > 3 && (
+													<div className="flex h-6 w-6 items-center justify-center rounded-full bg-secondary text-xs font-medium text-primary">
+														+{selectedUsers.length - 3}
+													</div>
+												)}
+											</div>
+										</div>
+									)}
+								</div>
 
 								{/* Users List */}
 								<div className="max-h-64 overflow-y-auto">
@@ -169,13 +221,10 @@ export const CreateDmModal = ({ isOpen, onOpenChange }: CreateDmModalProps) => {
 												<button
 													key={user?._id}
 													type="button"
-													onClick={() => {
-														setSelectedUser(user)
-														form.setFieldValue("userId", user?._id || "")
-													}}
+													onClick={() => user && toggleUserSelection(user)}
 													className={cx(
 														"flex w-full items-center justify-between rounded-lg p-3 text-left transition-colors hover:bg-secondary",
-														selectedUser?._id === user?._id &&
+														selectedUsers.some((u) => u._id === user?._id) &&
 															"bg-secondary ring-1 ring-border-brand ring-inset",
 													)}
 												>
@@ -202,7 +251,7 @@ export const CreateDmModal = ({ isOpen, onOpenChange }: CreateDmModalProps) => {
 															)}
 														</div>
 													</div>
-													{selectedUser?._id === user?._id && (
+													{selectedUsers.some((u) => u._id === user?._id) && (
 														<IconCheckTickCircle className="size-5 text-brand" />
 													)}
 												</button>
@@ -226,9 +275,13 @@ export const CreateDmModal = ({ isOpen, onOpenChange }: CreateDmModalProps) => {
 											color="primary"
 											size="lg"
 											onClick={form.handleSubmit}
-											isDisabled={!canSubmit || isSubmitting || !selectedUser}
+											isDisabled={!canSubmit || isSubmitting || selectedUsers.length === 0}
 										>
-											{isSubmitting ? "Creating..." : "Start conversation"}
+											{isSubmitting 
+												? "Creating..." 
+												: selectedUsers.length > 1 
+													? `Start group conversation (${selectedUsers.length})` 
+													: "Start conversation"}
 										</Button>
 									)}
 								</form.Subscribe>


### PR DESCRIPTION
Previously, the Create DM Dialog only supported single user direct messages, limiting users to one-on-one conversations. This update introduces functionality for both group DMs and single user DMs.

- Added a new mutation 'createGroupDmChannel' to handle group direct messaging.
- Updated the DM modal to allow selection of multiple users, reflecting changes in user interface and interaction.
- Implemented logic to differentiate between single and group DM requests, ensuring appropriate API calls.
- Adjusted user interface elements to provide feedback for multiple selections and added UI components to display avatars of selected users.
- Improved error-handling and feedback mechanisms to enhance user experience when creating group conversations.