### PR TITLE
Fix sidebar overflow issue in app

### DIFF
--- a/apps/web/src/components/app-sidebar/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar/app-sidebar.tsx
@@ -137,15 +137,17 @@ export const AppSidebar = () => {
 						<SidebarGroupAction>
 							<CreateDmButton />
 						</SidebarGroupAction>
-						<SidebarMenu>
-							{dmChannels.map((channel) => (
-								<DmChannelLink
-									key={channel._id}
-									userPresence={presenceList}
-									channel={channel}
-								/>
-							))}
-						</SidebarMenu>
+						<SidebarGroupContent>
+							<SidebarMenu>
+								{dmChannels.map((channel) => (
+									<DmChannelLink
+										key={channel._id}
+										userPresence={presenceList}
+										channel={channel}
+									/>
+								))}
+							</SidebarMenu>
+						</SidebarGroupContent>
 					</SidebarGroup>
 				</SidebarContent>
 			</Sidebar>


### PR DESCRIPTION
The app's sidebar experienced an issue where it overflowed, hiding the 'Add' buttons when the dmChannelItem expanded excessively. This change wraps the SidebarMenu with a SidebarGroupContent component to ensure that elements stay within the container size, thus maintaining proper visibility and functionality of the sidebar controls. The adjustment stops overflow and keeps buttons accessible regardless of channel size.