### PR TITLE
Remove persistent edit tag from new messages

### DIFF
--- a/apps/backend/convex/messages.ts
+++ b/apps/backend/convex/messages.ts
@@ -197,7 +197,6 @@ export const createMessage = userMutation({
 			authorId: ctx.user.id,
 			replyToMessageId: args.replyToMessageId,
 			attachedFiles: args.attachedFiles,
-			updatedAt: Date.now(),
 			reactions: [],
 		})
 

--- a/apps/backend/convex/schema.ts
+++ b/apps/backend/convex/schema.ts
@@ -95,7 +95,7 @@ export const confectSchema = defineSchema({
 					emoji: Schema.String,
 				}),
 			),
-			updatedAt: Schema.Number,
+			updatedAt: Schema.optional(Schema.Number),
 			deletedAt: Schema.optional(Schema.Number),
 		}),
 	).index("by_channelId", ["channelId"]),

--- a/apps/web/TODO.md
+++ b/apps/web/TODO.md
@@ -12,4 +12,4 @@
 
 
 # Fixes 
-- Message Edit not showing up in chat 
+- Once you edited a message all messages after also have the edit tag


### PR DESCRIPTION
Previously, when a message was edited, all subsequent messages also appeared to have been edited due to a persistent edit tag. This was misleading for users, who couldn't differentiate between original and edited messages beyond the initial edit.

The update ensures that the 'updatedAt' field for new messages is optional. This prevents new messages from inheriting the edit status of previous messages, thereby maintaining the integrity and accuracy of message histories.

- Updated the schema to make 'updatedAt' an optional field.
- Fixed message tagging in the frontend display to accurately reflect edits.