### PR TITLE
feat: Implement channel renaming functionality in sidebar

### DIFF
--- a/CHANNEL_RENAME_IMPLEMENTATION.md
+++ b/CHANNEL_RENAME_IMPLEMENTATION.md
@@ -1,0 +1,84 @@
+# Channel Rename Implementation
+
+## Summary
+This implementation adds working channel renaming functionality to the sidebar. Previously, the "Rename" menu item existed but had no functionality. Now users can rename channels through a modal dialog.
+
+## Files Modified
+
+### 1. `apps/web/src/components/app-sidebar/rename-channel-modal.tsx` (NEW)
+- **Purpose**: Modal component for renaming channels
+- **Features**:
+  - Input field pre-filled with current channel name
+  - Form validation (required, must be different from current)
+  - Loading states with disabled inputs and loading button
+  - Success/error toast notifications
+  - Auto-focus on input when modal opens
+  - Keyboard accessibility (Enter submits, Escape closes)
+  - Integration with existing API client and hooks
+
+### 2. `apps/web/src/components/app-sidebar/channel-item.tsx` (MODIFIED)
+- **Changes**:
+  - Added import for `RenameChannelModal`
+  - Wrapped the existing "Rename" dropdown item with the new modal component
+  - No other functionality affected
+
+## Technical Details
+
+### API Integration
+- Uses existing `PUT /channels/:id` endpoint
+- Leverages `ApiClient` service with Effect-TS pattern
+- Payload: `{ name: newChannelName }`
+- Error handling with try/catch and user feedback
+
+### State Management
+- Uses existing `useChannelWithCurrentUser` hook for channel data
+- Real-time updates through existing live query system
+- Local state for modal open/close, input value, and loading states
+
+### UI/UX
+- Modal opens when "Rename" is clicked in channel dropdown
+- Input field shows current channel name as starting value
+- "Rename Channel" button disabled until valid input entered
+- Loading spinner on button during API call
+- Success toast: "Channel renamed to '{newName}'"
+- Error toast: "Failed to rename channel. Please try again."
+
+### Validation Rules
+- Channel name is required (non-empty after trim)
+- New name must be different from current name
+- Maximum length: 255 characters (enforced by input)
+
+## Dependencies
+- All required dependencies already exist in the project:
+  - `sonner` for toast notifications ✅
+  - `effect` for API client ✅ 
+  - React Aria Components for modal/input ✅
+  - Existing button component ✅
+
+## Testing Considerations
+To test this feature:
+
+1. **Happy Path**:
+   - Navigate to a channel in sidebar
+   - Click three-dots menu → "Rename"
+   - Enter new channel name → click "Rename Channel"
+   - Verify success toast appears
+   - Verify channel name updates in sidebar immediately
+   - Verify channel name persists after page refresh
+
+2. **Error Cases**:
+   - Test with empty input (button should be disabled)
+   - Test with same name (button should be disabled)
+   - Test network failure scenario
+   - Test with very long names (255+ chars)
+
+3. **Accessibility**:
+   - Test keyboard navigation (Tab, Enter, Escape)
+   - Test screen reader compatibility
+   - Test focus management
+
+## Future Enhancements
+- Add character count indicator for long names
+- Add confirmation for potentially destructive renames
+- Add undo functionality
+- Add channel name validation (e.g., no special characters)

--- a/apps/web/src/components/app-sidebar/channel-item.tsx
+++ b/apps/web/src/components/app-sidebar/channel-item.tsx
@@ -17,6 +17,7 @@ import IconThreeDotsMenuHorizontalStroke from "../icons/IconThreeDotsMenuHorizon
 import IconVolumeMute1 from "../icons/IconVolumeMute1"
 import IconVolumeOne1 from "../icons/IconVolumeOne1"
 import { SidebarMenuAction, SidebarMenuButton, SidebarMenuItem } from "../ui/sidebar"
+import { RenameChannelModal } from "./rename-channel-modal"
 
 export interface ChannelItemProps {
 	channelId: ChannelId
@@ -98,13 +99,15 @@ export const ChannelItem = ({ channelId }: ChannelItemProps) => {
 							{channel.currentUser.isFavorite ? "Unfavorite" : "Favorite"}
 						</Dropdown.Item>
 						<Dropdown.Separator />
-						<Dropdown.Item
-							icon={(props) => (
-								<IconPencilEdit className={cx("text-amber-500", props.className)} />
-							)}
-						>
-							Rename
-						</Dropdown.Item>
+						<RenameChannelModal channelId={channelId}>
+							<Dropdown.Item
+								icon={(props) => (
+									<IconPencilEdit className={cx("text-amber-500", props.className)} />
+								)}
+							>
+								Rename
+							</Dropdown.Item>
+						</RenameChannelModal>
 						<Dropdown.Item
 							icon={(props) => (
 								<IconDeleteDustbin011 className={cx("text-amber-500", props.className)} />

--- a/apps/web/src/components/app-sidebar/rename-channel-modal.tsx
+++ b/apps/web/src/components/app-sidebar/rename-channel-modal.tsx
@@ -1,0 +1,129 @@
+import type { ChannelId } from "@hazel/db/schema"
+import { Effect, Option } from "effect"
+import { useCallback, useState } from "react"
+import { toast } from "sonner"
+import { useChannelWithCurrentUser } from "~/db/hooks"
+import { ApiClient } from "~/lib/services/common/api-client"
+import { Button } from "../base/buttons/button"
+import { Input } from "../base/input/input"
+import { Dialog, DialogTrigger, Modal, ModalFooter, ModalOverlay } from "../application/modals/modal"
+
+interface RenameChannelModalProps {
+	channelId: ChannelId
+	children: React.ReactNode
+}
+
+export const RenameChannelModal = ({ channelId, children }: RenameChannelModalProps) => {
+	const [isOpen, setIsOpen] = useState(false)
+	const [newName, setNewName] = useState("")
+	const [isLoading, setIsLoading] = useState(false)
+
+	const { channel } = useChannelWithCurrentUser(channelId)
+
+	const handleOpen = useCallback(() => {
+		if (channel) {
+			setNewName(channel.name)
+			setIsOpen(true)
+		}
+	}, [channel])
+
+	const handleClose = useCallback(() => {
+		setIsOpen(false)
+		setNewName("")
+	}, [])
+
+	const handleRename = useCallback(async () => {
+		if (!channel || !newName.trim() || newName.trim() === channel.name) {
+			return
+		}
+
+		setIsLoading(true)
+
+		try {
+			const result = await Effect.runPromise(
+				ApiClient.pipe(
+					Effect.flatMap((client) =>
+						client.channels.update({
+							path: { id: channelId },
+							payload: { name: newName.trim() },
+						}),
+					),
+				),
+			)
+
+			if (Option.isSome(result)) {
+				toast.success(`Channel renamed to "${newName.trim()}"`)
+				handleClose()
+			}
+		} catch (error) {
+			console.error("Failed to rename channel:", error)
+			toast.error("Failed to rename channel. Please try again.")
+		} finally {
+			setIsLoading(false)
+		}
+	}, [channel, channelId, newName, handleClose])
+
+	const handleSubmit = useCallback(
+		(e: React.FormEvent) => {
+			e.preventDefault()
+			handleRename()
+		},
+		[handleRename],
+	)
+
+	if (!channel) {
+		return null
+	}
+
+	return (
+		<DialogTrigger isOpen={isOpen} onOpenChange={setIsOpen}>
+			<div onClick={handleOpen}>{children}</div>
+
+			<ModalOverlay>
+				<Modal className="sm:w-96">
+					<Dialog>
+						<div className="space-y-6 p-6">
+							<div className="space-y-2">
+								<h2 className="font-semibold text-lg text-primary">Rename Channel</h2>
+								<p className="text-quaternary text-sm">
+									Choose a new name for the channel #{channel.name}
+								</p>
+							</div>
+
+							<form onSubmit={handleSubmit} className="space-y-4">
+								<Input
+									label="Channel name"
+									value={newName}
+									onChange={(e) => setNewName(e.target.value)}
+									placeholder="Enter channel name"
+									disabled={isLoading}
+									required
+									autoFocus
+									maxLength={255}
+								/>
+							</form>
+						</div>
+
+						<ModalFooter>
+							<Button
+								color="secondary"
+								onClick={handleClose}
+								isDisabled={isLoading}
+							>
+								Cancel
+							</Button>
+							<Button
+								color="primary"
+								onClick={handleRename}
+								isDisabled={isLoading || !newName.trim() || newName.trim() === channel.name}
+								isLoading={isLoading}
+							>
+								Rename Channel
+							</Button>
+						</ModalFooter>
+					</Dialog>
+				</Modal>
+			</ModalOverlay>
+		</DialogTrigger>
+	)
+}


### PR DESCRIPTION
## Summary
This PR implements working channel renaming functionality in the sidebar. Previously, the 'Rename' menu item existed but had no functionality.

## Changes Made
- **NEW**: `apps/web/src/components/app-sidebar/rename-channel-modal.tsx` - Modal component for renaming channels
- **MODIFIED**: `apps/web/src/components/app-sidebar/channel-item.tsx` - Connected rename menu item to modal
- **NEW**: `CHANNEL_RENAME_IMPLEMENTATION.md` - Implementation documentation

## Features
✅ Modal dialog with input validation  
✅ Loading states and error handling  
✅ Real-time updates via existing live query system  
✅ Toast notifications for success/error feedback  
✅ Accessibility support (keyboard navigation, auto-focus)  
✅ Integration with existing API endpoints  

## Quality Assurance
- ✅ Manual code review completed
- ✅ Follows existing TypeScript patterns and architecture
- ✅ Uses established UI components and design system
- ✅ Leverages existing API client and hooks

## Testing
To test:
1. Navigate to any channel in the sidebar
2. Click the three-dots menu → 'Rename'
3. Enter a new channel name and submit
4. Verify the channel name updates immediately

**Droid-assisted implementation** - Code follows established patterns and architecture.