### PR TITLE
Fix multiple file upload issue

### DIFF
--- a/apps/web/src/providers/chat-provider.tsx
+++ b/apps/web/src/providers/chat-provider.tsx
@@ -104,16 +104,16 @@ export function ChatProvider({ channelId, organizationId, children }: ChatProvid
 
 	const addAttachment = useCallback(
 		(attachmentId: AttachmentId) => {
-			setAttachmentIds([...attachmentIds, attachmentId])
+			setAttachmentIds((prev) => [...prev, attachmentId])
 		},
-		[attachmentIds, setAttachmentIds],
+		[setAttachmentIds],
 	)
 
 	const removeAttachment = useCallback(
 		(attachmentId: AttachmentId) => {
-			setAttachmentIds(attachmentIds.filter((id) => id !== attachmentId))
+			setAttachmentIds((prev) => prev.filter((id) => id !== attachmentId))
 		},
-		[attachmentIds, setAttachmentIds],
+		[setAttachmentIds],
 	)
 
 	const clearAttachments = useCallback(() => {
@@ -122,16 +122,16 @@ export function ChatProvider({ channelId, organizationId, children }: ChatProvid
 
 	const addUploadingFile = useCallback(
 		(file: UploadingFile) => {
-			setUploadingFiles([...uploadingFiles, file])
+			setUploadingFiles((prev) => [...prev, file])
 		},
-		[uploadingFiles, setUploadingFiles],
+		[setUploadingFiles],
 	)
 
 	const removeUploadingFile = useCallback(
 		(fileId: string) => {
-			setUploadingFiles(uploadingFiles.filter((f) => f.fileId !== fileId))
+			setUploadingFiles((prev) => prev.filter((f) => f.fileId !== fileId))
 		},
-		[uploadingFiles, setUploadingFiles],
+		[setUploadingFiles],
 	)
 
 	const sendMessage = useCallback(


### PR DESCRIPTION
The issue was caused by stale closures in the useCallback hooks for addAttachment, removeAttachment, addUploadingFile, and removeUploadingFile.

When files were uploaded sequentially, each callback would capture the state value at the time of its creation, causing subsequent uploads to overwrite previous ones instead of appending to the array.

Fixed by using functional state updates (prev => [...prev, newItem]) instead of direct state references, ensuring we always operate on the latest state value.

Changes:
- addAttachment: setAttachmentIds(prev => [...prev, attachmentId])
- removeAttachment: setAttachmentIds(prev => prev.filter(...))
- addUploadingFile: setUploadingFiles(prev => [...prev, file])
- removeUploadingFile: setUploadingFiles(prev => prev.filter(...))

This ensures proper accumulation of multiple file uploads in the message composer.