### PR TITLE
Fix authorization policy for integration connections

### DIFF
--- a/packages/domain/src/policy/index.ts
+++ b/packages/domain/src/policy/index.ts
@@ -22,18 +22,16 @@ export const policy = <Entity extends string, Action extends string, E, R>(
 	f: (actor: typeof CurrentUser.Schema.Type) => Effect.Effect<boolean, E, R>,
 ): Effect.Effect<AuthorizedActor<Entity, Action>, E | UnauthorizedError, R | CurrentUser.Context> =>
 	Effect.flatMap(CurrentUser.Context, (actor) =>
-		actor.role === "admin"
-			? Effect.succeed(authorizedActor(actor))
-			: Effect.flatMap(f(actor), (can) =>
-					can
-						? Effect.succeed(authorizedActor(actor))
-						: Effect.fail(
-								new UnauthorizedError({
-									message: `You can't ${action} this ${entity}`,
-									detail: `You are not authorized to perform ${action} on ${entity} for ${actor.id}`,
-								}),
-							),
-				),
+		Effect.flatMap(f(actor), (can) =>
+			can
+				? Effect.succeed(authorizedActor(actor))
+				: Effect.fail(
+						new UnauthorizedError({
+							message: `You can't ${action} this ${entity}`,
+							detail: `You are not authorized to perform ${action} on ${entity} for ${actor.id}`,
+						}),
+					),
+		),
 	)
 
 export const policyCompose =


### PR DESCRIPTION
…rg privilege escalation

The policy function had a global admin bypass that granted access to users with role="admin" before checking organization-specific permissions. This allowed admins from one organization to perform privileged operations on other organizations' resources.

The fix removes the `actor.role === "admin"` bypass, ensuring that all policy checks are properly enforced regardless of the user's role. Each policy function must now explicitly verify the user's authorization for the specific resource and organization being accessed.

Security impact: CWE-269 (Improper Privilege Management)