### PR TITLE
feat(integrations): add GitHub star event support

### DIFF
--- a/apps/web/src/components/integrations/add-github-subscription-modal.tsx
+++ b/apps/web/src/components/integrations/add-github-subscription-modal.tsx
@@ -32,6 +32,7 @@ const EVENT_OPTIONS: { id: GitHubEventType; label: string; description: string }
 	{ id: "release", label: "Releases", description: "New releases published" },
 	{ id: "deployment_status", label: "Deployments", description: "Deployment status changes" },
 	{ id: "workflow_run", label: "Workflows", description: "GitHub Actions workflow runs" },
+	{ id: "star", label: "Stars", description: "Repository starred or unstarred" },
 ]
 
 interface AddGitHubSubscriptionModalProps {

--- a/packages/integrations/src/github/colors.ts
+++ b/packages/integrations/src/github/colors.ts
@@ -31,6 +31,9 @@ export const GITHUB_COLORS = {
 	workflow_failure: 0xda3633, // Red
 	workflow_cancelled: 0x6e7681, // Gray
 	workflow_pending: 0xdbab09, // Yellow
+
+	// Star events
+	star: 0xf1e05a, // GitHub yellow/gold star color
 } as const
 
 export type GitHubColorKey = keyof typeof GITHUB_COLORS

--- a/packages/integrations/src/github/payloads.ts
+++ b/packages/integrations/src/github/payloads.ts
@@ -154,6 +154,16 @@ export const GitHubWorkflowRunPayload = Schema.Struct({
 
 export type GitHubWorkflowRunPayload = Schema.Schema.Type<typeof GitHubWorkflowRunPayload>
 
+// Star event
+export const GitHubStarPayload = Schema.Struct({
+	action: Schema.String, // "created" or "deleted"
+	starred_at: Schema.NullOr(Schema.String),
+	repository: GitHubRepository,
+	sender: Schema.optional(GitHubUser),
+})
+
+export type GitHubStarPayload = Schema.Schema.Type<typeof GitHubStarPayload>
+
 /**
  * Union of all GitHub webhook payload types.
  */
@@ -164,6 +174,7 @@ export type GitHubWebhookPayload =
 	| GitHubReleasePayload
 	| GitHubDeploymentStatusPayload
 	| GitHubWorkflowRunPayload
+	| GitHubStarPayload
 
 /**
  * GitHub event types supported by the integration.
@@ -175,6 +186,7 @@ export const GitHubEventType = Schema.Literal(
 	"release",
 	"deployment_status",
 	"workflow_run",
+	"star",
 )
 export type GitHubEventType = Schema.Schema.Type<typeof GitHubEventType>
 


### PR DESCRIPTION
## Summary
- Add support for GitHub star events in channel subscriptions
- Users can now get notified when someone stars their repository
- Includes starred/unstarred badge and gold star color

## Changes
- `packages/integrations/src/github/payloads.ts` - Added `"star"` event type and payload schema
- `packages/integrations/src/github/colors.ts` - Added gold star color
- `packages/integrations/src/github/embed-builder.ts` - Added `buildStarEmbed()` function
- `apps/web/src/components/integrations/add-github-subscription-modal.tsx` - Added "Stars" option

## Test plan
- [ ] Enable "Star" event in GitHub App webhook settings
- [ ] Create/update a subscription with Stars enabled
- [ ] Star a subscribed repository
- [ ] Verify star notification appears in channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)