### PR TITLE
fix(integrations): add star option to edit modal and section display

### DIFF
--- a/apps/web/src/components/integrations/edit-github-subscription-modal.tsx
+++ b/apps/web/src/components/integrations/edit-github-subscription-modal.tsx
@@ -32,6 +32,7 @@ const EVENT_OPTIONS: { id: GitHubEventType; label: string; description: string }
 	{ id: "release", label: "Releases", description: "New releases published" },
 	{ id: "deployment_status", label: "Deployments", description: "Deployment status changes" },
 	{ id: "workflow_run", label: "Workflows", description: "GitHub Actions workflow runs" },
+	{ id: "star", label: "Stars", description: "Repository starred or unstarred" },
 ]
 
 interface EditGitHubSubscriptionModalProps {

--- a/apps/web/src/components/integrations/github-subscriptions-section.tsx
+++ b/apps/web/src/components/integrations/github-subscriptions-section.tsx
@@ -38,6 +38,7 @@ const EVENT_LABELS: Record<string, string> = {
 	release: "Releases",
 	deployment_status: "Deploy",
 	workflow_run: "Actions",
+	star: "Stars",
 }
 
 export function GitHubSubscriptionsSection({ organizationId }: GitHubSubscriptionsSectionProps) {


### PR DESCRIPTION
## Summary
- Add missing "star" event type to the edit subscription modal
- Add missing "star" label to the subscriptions section display

Fixes the star option only appearing in the "Add" modal but not in "Edit" or the section list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)