### PR TITLE
fix: add public-read ACL to avatar upload

### DIFF
--- a/apps/backend/src/routes/avatars.http.ts
+++ b/apps/backend/src/routes/avatars.http.ts
@@ -28,6 +28,7 @@ export const HttpAvatarLive = HttpApiBuilder.group(HazelApi, "avatars", (handler
 				// Generate presigned URL
 				const uploadUrl = yield* s3
 					.presign(key, {
+						acl: "public-read",
 						method: "PUT",
 						type: payload.contentType,
 						expiresIn: 300, // 5 minutes


### PR DESCRIPTION
## Summary
- Added missing `acl: "public-read"` to avatar presigned URL generation
- Matches existing behavior in attachment uploads

## Root Cause
Avatar uploads were generating presigned URLs without the public-read ACL, so uploaded files were private and couldn't be displayed after upload.

## Test plan
- [ ] Upload a new avatar in Settings > Profile
- [ ] Verify the image displays immediately after upload
- [ ] Refresh the page and confirm the avatar persists

Fixes #214

🤖 Generated with [Claude Code](https://claude.ai/code)