### PR TITLE
fix(web): resolve React hooks order violation in MessageList

### DIFF
--- a/apps/web/src/components/chat/message-list.tsx
+++ b/apps/web/src/components/chat/message-list.tsx
@@ -226,6 +226,15 @@ export function MessageList({ ref }: { ref?: React.Ref<MessageListRef> }) {
 		return { messageRows: rows, stickyIndices: sticky }
 	}, [processedMessages])
 
+	const containerStyle = useMemo(
+		() => ({
+			overflowAnchor: "auto" as const,
+			scrollBehavior: "auto" as const,
+			opacity: isLoading && messages.length > 0 ? 0.7 : 1,
+		}),
+		[isLoading, messages.length],
+	)
+
 	// Show empty state if no messages (no skeleton loader needed since route loader preloads data)
 	if (messages.length === 0) {
 		return (
@@ -241,16 +250,6 @@ export function MessageList({ ref }: { ref?: React.Ref<MessageListRef> }) {
 			</div>
 		)
 	}
-
-	// Memoize container style to avoid object recreation on each render
-	const containerStyle = useMemo(
-		() => ({
-			overflowAnchor: "auto" as const,
-			scrollBehavior: "auto" as const,
-			opacity: isLoading && messages.length > 0 ? 0.7 : 1,
-		}),
-		[isLoading, messages.length],
-	)
 
 	return (
 		<div

--- a/apps/web/src/components/modals/create-dm-modal.tsx
+++ b/apps/web/src/components/modals/create-dm-modal.tsx
@@ -97,11 +97,10 @@ export function CreateDmModal({ isOpen, onOpenChange }: CreateDmModalProps) {
 				}),
 				{
 					loading: "Creating conversation...",
-					success: (_result) => {
-						// Navigate back to org page (TODO: navigate to channel when route exists)
+					success: (result) => {
 						navigate({
-							to: "/$orgSlug",
-							params: { orgSlug: slug },
+							to: "/$orgSlug/chat/$id",
+							params: { orgSlug: slug, id: result.data.id },
 						})
 
 						// Close modal and reset form


### PR DESCRIPTION
Fix 'Rendered fewer hooks than expected' error that occurred when:
1. Creating a new channel and clicking on it for the first time
2. Sending the first message in an empty channel

The bug was caused by a useMemo hook (containerStyle) being placed AFTER a conditional early return in the MessageList component. When navigating to a channel with 0 messages, the component would return early, skipping the useMemo. When messages appeared (either from loading or sending), React detected more hooks were being called than in the previous render.

The fix moves the containerStyle useMemo before the conditional return, ensuring all hooks are called in the same order on every render, satisfying React's rules of hooks.
<img width="961" height="717" alt="Bildschirmfoto 2026-01-18 um 17 45 54" src="https://github.com/user-attachments/assets/425e5a79-3db9-4fc9-9986-d86bb2ba705e" />



