### PR TITLE
Fix typing indicators and add diagnostics

### DIFF
--- a/apps/backend/src/rpc/handlers/typing-indicators.ts
+++ b/apps/backend/src/rpc/handlers/typing-indicators.ts
@@ -31,6 +31,12 @@ export const TypingIndicatorRpcLive = TypingIndicatorRpcs.toLayer(
 				db
 					.transaction(
 						Effect.gen(function* () {
+							const startedAt = Date.now()
+							yield* Effect.logDebug("typingIndicator.create received", {
+								channelId: payload.channelId,
+								memberId: payload.memberId,
+							})
+
 							// Use upsert to create or update typing indicator
 							const result = yield* TypingIndicatorRepo.upsertByChannelAndMember({
 								channelId: payload.channelId,
@@ -41,6 +47,12 @@ export const TypingIndicatorRpcLive = TypingIndicatorRpcs.toLayer(
 							const typingIndicator = result[0]!
 
 							const txid = yield* generateTransactionId()
+							yield* Effect.logDebug("typingIndicator.create succeeded", {
+								channelId: payload.channelId,
+								memberId: payload.memberId,
+								typingIndicatorId: typingIndicator.id,
+								durationMs: Date.now() - startedAt,
+							})
 
 							return {
 								data: typingIndicator,
@@ -54,6 +66,11 @@ export const TypingIndicatorRpcLive = TypingIndicatorRpcs.toLayer(
 				db
 					.transaction(
 						Effect.gen(function* () {
+							const startedAt = Date.now()
+							yield* Effect.logDebug("typingIndicator.update received", {
+								typingIndicatorId: id,
+							})
+
 							const typingIndicator = yield* TypingIndicatorRepo.update({
 								...payload,
 								id,
@@ -61,6 +78,10 @@ export const TypingIndicatorRpcLive = TypingIndicatorRpcs.toLayer(
 							}).pipe(policyUse(TypingIndicatorPolicy.canUpdate(id)))
 
 							const txid = yield* generateTransactionId()
+							yield* Effect.logDebug("typingIndicator.update succeeded", {
+								typingIndicatorId: id,
+								durationMs: Date.now() - startedAt,
+							})
 
 							return {
 								data: typingIndicator,
@@ -74,6 +95,11 @@ export const TypingIndicatorRpcLive = TypingIndicatorRpcs.toLayer(
 				db
 					.transaction(
 						Effect.gen(function* () {
+							const startedAt = Date.now()
+							yield* Effect.logDebug("typingIndicator.delete received", {
+								typingIndicatorId: id,
+							})
+
 							// First find the typing indicator to return it
 							const existingOption = yield* TypingIndicatorRepo.findById(id).pipe(
 								policyUse(TypingIndicatorPolicy.canRead(id)),
@@ -92,6 +118,12 @@ export const TypingIndicatorRpcLive = TypingIndicatorRpcs.toLayer(
 							)
 
 							const txid = yield* generateTransactionId()
+							yield* Effect.logDebug("typingIndicator.delete succeeded", {
+								typingIndicatorId: id,
+								memberId: existing.memberId,
+								channelId: existing.channelId,
+								durationMs: Date.now() - startedAt,
+							})
 
 							return { data: existing, transactionId: txid }
 						}),

--- a/apps/cluster/src/cron/typing-indicator-cleanup-cron.ts
+++ b/apps/cluster/src/cron/typing-indicator-cleanup-cron.ts
@@ -1,0 +1,38 @@
+import * as ClusterCron from "@effect/cluster/ClusterCron"
+import { Database, lt, schema } from "@hazel/db"
+import * as Cron from "effect/Cron"
+import * as Duration from "effect/Duration"
+import * as Effect from "effect/Effect"
+
+const every5Seconds = Cron.unsafeParse("*/5 * * * * *")
+const TYPING_INDICATOR_STALE_MS = 12_000
+
+/**
+ * Cron job that hard-deletes stale typing indicators.
+ * This is a server-side safety net for abandoned indicators (tab crash, network drop, etc.).
+ */
+export const TypingIndicatorCleanupCronLayer = ClusterCron.make({
+	name: "TypingIndicatorCleanup",
+	cron: every5Seconds,
+	execute: Effect.gen(function* () {
+		const db = yield* Database.Database
+		const staleThreshold = Date.now() - TYPING_INDICATOR_STALE_MS
+
+		const deleted = yield* db.execute((client) =>
+			client
+				.delete(schema.typingIndicatorsTable)
+				.where(lt(schema.typingIndicatorsTable.lastTyped, staleThreshold))
+				.returning({
+					id: schema.typingIndicatorsTable.id,
+				}),
+		)
+
+		if (deleted.length > 0) {
+			yield* Effect.logDebug("Deleted stale typing indicators", {
+				count: deleted.length,
+				thresholdMs: TYPING_INDICATOR_STALE_MS,
+			})
+		}
+	}),
+	skipIfOlderThan: Duration.minutes(1),
+})

--- a/apps/cluster/src/index.ts
+++ b/apps/cluster/src/index.ts
@@ -17,6 +17,7 @@ import { createTracingLayer } from "@hazel/effect-bun/Telemetry"
 import { Config, Effect, Layer, Logger, Redacted } from "effect"
 import { PresenceCleanupCronLayer } from "./cron/presence-cleanup-cron.ts"
 import { StatusExpirationCronLayer } from "./cron/status-expiration-cron.ts"
+import { TypingIndicatorCleanupCronLayer } from "./cron/typing-indicator-cleanup-cron.ts"
 import { UploadCleanupCronLayer } from "./cron/upload-cleanup-cron.ts"
 import { WorkOSSyncCronLayer } from "./cron/workos-sync-cron.ts"
 import { BotUserServiceLive } from "./services/bot-user-service.ts"
@@ -80,6 +81,7 @@ const AllCronJobs = Layer.mergeAll(
 	WorkOSSyncCronLayer.pipe(Layer.provide(WorkOSSyncLive)),
 	PresenceCleanupCronLayer.pipe(Layer.provide(DatabaseLayer)),
 	StatusExpirationCronLayer.pipe(Layer.provide(DatabaseLayer)),
+	TypingIndicatorCleanupCronLayer.pipe(Layer.provide(DatabaseLayer)),
 	UploadCleanupCronLayer.pipe(Layer.provide(DatabaseLayer)),
 	RssPollCronLayer.pipe(Layer.provide(DatabaseLayer)),
 ).pipe(Layer.provide(WorkflowEngineLayer))

--- a/apps/web/src/db/collections.ts
+++ b/apps/web/src/db/collections.ts
@@ -263,7 +263,7 @@ export const attachmentCollection = createEffectCollection({
 
 export const typingIndicatorCollection = createEffectCollection({
 	id: "typing_indicators",
-	syncMode: "on-demand",
+	syncMode: "eager",
 	runtime: runtime,
 	backoff: false,
 	shapeOptions: {

--- a/apps/web/src/hooks/use-typing.test.tsx
+++ b/apps/web/src/hooks/use-typing.test.tsx
@@ -1,0 +1,174 @@
+import { renderHook, act } from "@testing-library/react"
+import { Exit } from "effect"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { useTyping } from "./use-typing"
+
+const { upsertMutationSymbol, deleteMutationSymbol, upsertMock, deleteMock } = vi.hoisted(() => ({
+	upsertMutationSymbol: Symbol.for("typing.upsert"),
+	deleteMutationSymbol: Symbol.for("typing.delete"),
+	upsertMock: vi.fn(),
+	deleteMock: vi.fn(),
+}))
+
+vi.mock("~/atoms/typing-indicator-atom", () => ({
+	upsertTypingIndicatorMutation: upsertMutationSymbol,
+	deleteTypingIndicatorMutation: deleteMutationSymbol,
+}))
+
+vi.mock("~/lib/typing-diagnostics", () => ({
+	pushTypingDiagnostics: vi.fn(),
+}))
+
+vi.mock("@effect-atom/atom-react", () => ({
+	useAtomSet: vi.fn((mutation: unknown) => {
+		if (mutation === upsertMutationSymbol) return upsertMock
+		if (mutation === deleteMutationSymbol) return deleteMock
+		throw new Error("Unknown mutation atom in useTyping test")
+	}),
+}))
+
+const flushMicrotasks = async () => {
+	await act(async () => {
+		await Promise.resolve()
+	})
+}
+
+describe("useTyping", () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+		vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"))
+		upsertMock.mockReset()
+		deleteMock.mockReset()
+		upsertMock.mockResolvedValue(
+			Exit.succeed({
+				data: { id: "typing-indicator-1" },
+				transactionId: 1,
+			}) as any,
+		)
+		deleteMock.mockResolvedValue(
+			Exit.succeed({
+				data: { id: "typing-indicator-1" },
+				transactionId: 1,
+			}) as any,
+		)
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it("sends heartbeat immediately on first non-empty content and throttles subsequent heartbeats", async () => {
+		const { result } = renderHook(() =>
+			useTyping({
+				channelId: "channel-1" as any,
+				memberId: "member-1" as any,
+				heartbeatInterval: 1500,
+			}),
+		)
+
+		act(() => {
+			result.current.handleContentChange("h")
+		})
+		await flushMicrotasks()
+		expect(upsertMock).toHaveBeenCalledTimes(1)
+
+		act(() => {
+			result.current.handleContentChange("he")
+		})
+		await flushMicrotasks()
+		expect(upsertMock).toHaveBeenCalledTimes(1)
+
+		act(() => {
+			vi.advanceTimersByTime(1500)
+		})
+		act(() => {
+			result.current.handleContentChange("hel")
+		})
+		await flushMicrotasks()
+		expect(upsertMock).toHaveBeenCalledTimes(2)
+	})
+
+	it("deletes typing indicator when content becomes empty", async () => {
+		const { result } = renderHook(() =>
+			useTyping({
+				channelId: "channel-1" as any,
+				memberId: "member-1" as any,
+			}),
+		)
+
+		act(() => {
+			result.current.handleContentChange("hello")
+		})
+		await flushMicrotasks()
+
+		act(() => {
+			result.current.handleContentChange("")
+		})
+		await flushMicrotasks()
+
+		expect(deleteMock).toHaveBeenCalledTimes(1)
+		expect(deleteMock).toHaveBeenCalledWith({
+			payload: {
+				id: "typing-indicator-1",
+			},
+		})
+	})
+
+	it("auto-stops after typing timeout and deletes indicator", async () => {
+		const { result } = renderHook(() =>
+			useTyping({
+				channelId: "channel-1" as any,
+				memberId: "member-1" as any,
+				typingTimeout: 3000,
+			}),
+		)
+
+		act(() => {
+			result.current.handleContentChange("hello")
+		})
+		await flushMicrotasks()
+		expect(result.current.isTyping).toBe(true)
+
+		await act(async () => {
+			vi.advanceTimersByTime(3000)
+			await Promise.resolve()
+		})
+
+		expect(result.current.isTyping).toBe(false)
+		expect(deleteMock).toHaveBeenCalledTimes(1)
+	})
+
+	it("cleans up previous indicator when channel/member context changes", async () => {
+		const { result, rerender } = renderHook(
+			(props: { channelId: string; memberId: string }) =>
+				useTyping({
+					channelId: props.channelId as any,
+					memberId: props.memberId as any,
+				}),
+			{
+				initialProps: {
+					channelId: "channel-1",
+					memberId: "member-1",
+				},
+			},
+		)
+
+		act(() => {
+			result.current.handleContentChange("hello")
+		})
+		await flushMicrotasks()
+
+		rerender({
+			channelId: "channel-2",
+			memberId: "member-2",
+		})
+		await flushMicrotasks()
+
+		expect(deleteMock).toHaveBeenCalledTimes(1)
+		expect(deleteMock).toHaveBeenCalledWith({
+			payload: {
+				id: "typing-indicator-1",
+			},
+		})
+	})
+})

--- a/apps/web/src/hooks/use-typing.ts
+++ b/apps/web/src/hooks/use-typing.ts
@@ -3,12 +3,15 @@ import type { ChannelId, ChannelMemberId, TypingIndicatorId } from "@hazel/schem
 import { Exit } from "effect"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { deleteTypingIndicatorMutation, upsertTypingIndicatorMutation } from "~/atoms/typing-indicator-atom"
+import { pushTypingDiagnostics } from "~/lib/typing-diagnostics"
 
 interface UseTypingOptions {
 	channelId: ChannelId
 	memberId: ChannelMemberId | null
 	onTypingStart?: () => void
 	onTypingStop?: () => void
+	heartbeatInterval?: number
+	/** @deprecated Use heartbeatInterval instead. */
 	debounceDelay?: number
 	typingTimeout?: number
 }
@@ -25,15 +28,18 @@ export function useTyping({
 	memberId,
 	onTypingStart,
 	onTypingStop,
-	debounceDelay = 500,
-	typingTimeout = 3000,
+	heartbeatInterval,
+	debounceDelay,
+	typingTimeout = 6000,
 }: UseTypingOptions): UseTypingResult {
+	const heartbeatIntervalMs = heartbeatInterval ?? debounceDelay ?? 1500
 	const [isTyping, setIsTyping] = useState(false)
 	const lastContentRef = useRef("")
-	const lastTypedRef = useRef<number>(0)
-	const debounceTimerRef = useRef<NodeJS.Timeout | null>(null)
+	const isTypingRef = useRef(false)
+	const lastHeartbeatRef = useRef<number>(0)
 	const typingTimeoutRef = useRef<NodeJS.Timeout | null>(null)
-	const typingIndicatorIdRef = useRef<string | null>(null)
+	const typingIndicatorIdRef = useRef<TypingIndicatorId | null>(null)
+	const sessionIdRef = useRef(0)
 
 	const upsertTypingIndicator = useAtomSet(upsertTypingIndicatorMutation, {
 		mode: "promiseExit",
@@ -42,92 +48,173 @@ export function useTyping({
 	const deleteTypingIndicator = useAtomSet(deleteTypingIndicatorMutation, {
 		mode: "promiseExit",
 	})
-	// biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
-	const startTyping = useCallback(async () => {
-		if (!memberId) return
+	const deleteIndicatorById = useCallback(
+		async (typingIndicatorId: TypingIndicatorId, details?: Record<string, unknown>) => {
+			const result = await deleteTypingIndicator({
+				payload: {
+					id: typingIndicatorId,
+				},
+			})
 
-		const now = Date.now()
-		const timeSinceLastTyped = now - lastTypedRef.current
-
-		if (debounceTimerRef.current) {
-			clearTimeout(debounceTimerRef.current)
-		}
-		if (typingTimeoutRef.current) {
-			clearTimeout(typingTimeoutRef.current)
-		}
-
-		if (!isTyping) {
-			setIsTyping(true)
-			onTypingStart?.()
-		}
-
-		debounceTimerRef.current = setTimeout(async () => {
-			if (timeSinceLastTyped >= debounceDelay) {
-				lastTypedRef.current = now
-
-				const result = await upsertTypingIndicator({
-					payload: {
-						channelId,
-						memberId,
-						lastTyped: now,
-					},
-				})
-
-				if (Exit.isSuccess(result)) {
-					typingIndicatorIdRef.current = result.value.data.id
-				} else {
-					console.error(
-						"Failed to create typing indicator:",
-						Exit.match(result, {
-							onFailure: (cause) => cause,
-							onSuccess: () => null,
-						}),
-					)
+			if (Exit.isSuccess(result)) {
+				if (typingIndicatorIdRef.current === typingIndicatorId) {
+					typingIndicatorIdRef.current = null
 				}
+				pushTypingDiagnostics({
+					kind: "rpc_delete_success",
+					channelId,
+					memberId,
+					typingIndicatorId,
+					details,
+				})
+				return
 			}
-		}, debounceDelay)
 
-		typingTimeoutRef.current = setTimeout(() => {
-			stopTyping()
-		}, typingTimeout)
-	}, [channelId, memberId, debounceDelay, typingTimeout, isTyping, onTypingStart, upsertTypingIndicator])
+			const error = Exit.match(result, {
+				onFailure: (cause) => cause,
+				onSuccess: () => null,
+			})
+			pushTypingDiagnostics({
+				kind: "rpc_delete_failure",
+				channelId,
+				memberId,
+				typingIndicatorId,
+				details: {
+					...details,
+					error,
+				},
+			})
+			console.error("Failed to delete typing indicator:", error)
+		},
+		[channelId, memberId, deleteTypingIndicator],
+	)
 
 	const stopTyping = useCallback(async () => {
-		if (debounceTimerRef.current) {
-			clearTimeout(debounceTimerRef.current)
-			debounceTimerRef.current = null
-		}
 		if (typingTimeoutRef.current) {
 			clearTimeout(typingTimeoutRef.current)
 			typingTimeoutRef.current = null
 		}
 
-		if (isTyping) {
+		if (isTypingRef.current) {
+			isTypingRef.current = false
+			sessionIdRef.current += 1
+			lastHeartbeatRef.current = 0
 			setIsTyping(false)
 			onTypingStop?.()
+			pushTypingDiagnostics({
+				kind: "stop_requested",
+				channelId,
+				memberId,
+				typingIndicatorId: typingIndicatorIdRef.current,
+			})
 		}
 
-		if (typingIndicatorIdRef.current) {
-			const result = await deleteTypingIndicator({
+		const typingIndicatorId = typingIndicatorIdRef.current
+		if (typingIndicatorId) {
+			typingIndicatorIdRef.current = null
+			await deleteIndicatorById(typingIndicatorId, {
+				reason: "stop",
+			})
+		}
+	}, [channelId, memberId, onTypingStop, deleteIndicatorById])
+
+	const sendTypingHeartbeat = useCallback(
+		async (sessionId: number, now: number) => {
+			if (!memberId) return
+
+			const result = await upsertTypingIndicator({
 				payload: {
-					id: typingIndicatorIdRef.current as TypingIndicatorId,
+					channelId,
+					memberId,
+					lastTyped: now,
 				},
 			})
 
 			if (Exit.isSuccess(result)) {
-				typingIndicatorIdRef.current = null
-				lastTypedRef.current = 0
-			} else {
-				console.error(
-					"Failed to delete typing indicator:",
-					Exit.match(result, {
-						onFailure: (cause) => cause,
-						onSuccess: () => null,
-					}),
-				)
+				const typingIndicatorId = result.value.data.id
+				pushTypingDiagnostics({
+					kind: "rpc_upsert_success",
+					channelId,
+					memberId,
+					typingIndicatorId,
+				})
+
+				if (sessionId !== sessionIdRef.current) {
+					await deleteIndicatorById(typingIndicatorId, {
+						reason: "stale_session",
+					})
+					return
+				}
+
+				typingIndicatorIdRef.current = typingIndicatorId
+				return
 			}
+
+			const error = Exit.match(result, {
+				onFailure: (cause) => cause,
+				onSuccess: () => null,
+			})
+			pushTypingDiagnostics({
+				kind: "rpc_upsert_failure",
+				channelId,
+				memberId,
+				details: {
+					error,
+				},
+			})
+			console.error("Failed to create typing indicator:", error)
+		},
+		[channelId, memberId, upsertTypingIndicator, deleteIndicatorById],
+	)
+
+	const startTyping = useCallback(() => {
+		if (!memberId) return
+
+		const now = Date.now()
+
+		if (!isTypingRef.current) {
+			sessionIdRef.current += 1
+			isTypingRef.current = true
+			setIsTyping(true)
+			onTypingStart?.()
+			pushTypingDiagnostics({
+				kind: "start_requested",
+				channelId,
+				memberId,
+				typingIndicatorId: typingIndicatorIdRef.current,
+			})
 		}
-	}, [isTyping, onTypingStop, deleteTypingIndicator])
+		const sessionId = sessionIdRef.current
+
+		if (now - lastHeartbeatRef.current >= heartbeatIntervalMs) {
+			lastHeartbeatRef.current = now
+			pushTypingDiagnostics({
+				kind: "heartbeat_sent",
+				channelId,
+				memberId,
+				typingIndicatorId: typingIndicatorIdRef.current,
+				details: {
+					heartbeatIntervalMs,
+				},
+			})
+			void sendTypingHeartbeat(sessionId, now)
+		}
+
+		if (typingTimeoutRef.current) {
+			clearTimeout(typingTimeoutRef.current)
+		}
+		typingTimeoutRef.current = setTimeout(() => {
+			void stopTyping()
+		}, typingTimeout)
+	}, [
+		channelId,
+		memberId,
+		heartbeatIntervalMs,
+		typingTimeout,
+		onTypingStart,
+		sendTypingHeartbeat,
+		stopTyping,
+	])
 
 	const handleContentChange = useCallback(
 		(content: string) => {
@@ -137,7 +224,7 @@ export function useTyping({
 			lastContentRef.current = content
 
 			if (isEmpty && !wasEmpty) {
-				stopTyping()
+				void stopTyping()
 			} else if (!isEmpty && wasEmpty) {
 				startTyping()
 			} else if (!isEmpty) {
@@ -148,15 +235,36 @@ export function useTyping({
 	)
 
 	useEffect(() => {
-		return () => {
-			if (debounceTimerRef.current) {
-				clearTimeout(debounceTimerRef.current)
-			}
-			if (typingTimeoutRef.current) {
-				clearTimeout(typingTimeoutRef.current)
+		sessionIdRef.current += 1
+		lastHeartbeatRef.current = 0
+		lastContentRef.current = ""
+		void stopTyping()
+	}, [channelId, memberId, stopTyping])
+
+	useEffect(() => {
+		const handleVisibilityChange = () => {
+			if (document.visibilityState === "hidden") {
+				void stopTyping()
 			}
 		}
-	}, [])
+		const handleBlur = () => {
+			void stopTyping()
+		}
+
+		window.addEventListener("blur", handleBlur)
+		document.addEventListener("visibilitychange", handleVisibilityChange)
+
+		return () => {
+			window.removeEventListener("blur", handleBlur)
+			document.removeEventListener("visibilitychange", handleVisibilityChange)
+		}
+	}, [stopTyping])
+
+	useEffect(() => {
+		return () => {
+			void stopTyping()
+		}
+	}, [stopTyping])
 
 	return {
 		isTyping,

--- a/apps/web/src/lib/typing-diagnostics/diagnostics-store.ts
+++ b/apps/web/src/lib/typing-diagnostics/diagnostics-store.ts
@@ -1,0 +1,39 @@
+import type { TypingDiagnosticsEvent } from "./types"
+
+const MAX_RECORDS = 300
+const records: TypingDiagnosticsEvent[] = []
+const listeners = new Set<() => void>()
+
+const emit = () => {
+	for (const listener of listeners) {
+		listener()
+	}
+}
+
+export const pushTypingDiagnostics = (event: Omit<TypingDiagnosticsEvent, "id" | "at">) => {
+	const record: TypingDiagnosticsEvent = {
+		id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+		at: Date.now(),
+		...event,
+	}
+
+	records.unshift(record)
+	if (records.length > MAX_RECORDS) {
+		records.length = MAX_RECORDS
+	}
+	emit()
+}
+
+export const getTypingDiagnostics = () => records
+
+export const clearTypingDiagnostics = () => {
+	records.length = 0
+	emit()
+}
+
+export const subscribeTypingDiagnostics = (listener: () => void) => {
+	listeners.add(listener)
+	return () => {
+		listeners.delete(listener)
+	}
+}

--- a/apps/web/src/lib/typing-diagnostics/index.ts
+++ b/apps/web/src/lib/typing-diagnostics/index.ts
@@ -1,0 +1,7 @@
+export {
+	clearTypingDiagnostics,
+	getTypingDiagnostics,
+	pushTypingDiagnostics,
+	subscribeTypingDiagnostics,
+} from "./diagnostics-store"
+export type { TypingDiagnosticsEvent, TypingDiagnosticsEventKind } from "./types"

--- a/apps/web/src/lib/typing-diagnostics/types.ts
+++ b/apps/web/src/lib/typing-diagnostics/types.ts
@@ -1,0 +1,19 @@
+export type TypingDiagnosticsEventKind =
+	| "start_requested"
+	| "heartbeat_sent"
+	| "stop_requested"
+	| "rpc_upsert_success"
+	| "rpc_upsert_failure"
+	| "rpc_delete_success"
+	| "rpc_delete_failure"
+	| "collection_state"
+
+export interface TypingDiagnosticsEvent {
+	id: string
+	at: number
+	kind: TypingDiagnosticsEventKind
+	channelId?: string
+	memberId?: string | null
+	typingIndicatorId?: string | null
+	details?: Record<string, unknown>
+}


### PR DESCRIPTION
## Summary
- repair typing indicator emission to use immediate + throttled heartbeats with safer stop/cleanup semantics
- add typing diagnostics store + debug settings panel for lifecycle and collection health visibility
- add backend typing RPC structured logs and cluster cron cleanup for stale typing indicators
- add hook tests covering heartbeat, timeout stop, empty-content stop, and context-switch cleanup

## Validation
- bun run --cwd apps/web test -- src/hooks/use-typing.test.tsx
- bun run --cwd apps/web typecheck
- bun run --cwd apps/backend typecheck
- bun run --cwd apps/cluster typecheck
