### PR TITLE
fix: drop avatarUrl from Maple webhook create payload

### DIFF
--- a/apps/web/src/components/channel-settings/maple-section.tsx
+++ b/apps/web/src/components/channel-settings/maple-section.tsx
@@ -64,7 +64,6 @@ export function MapleSection({
 				channelId,
 				name: MAPLE_NAME,
 				description: "Maple alert notifications",
-				avatarUrl: mapleLogoUrl,
 				integrationProvider: "maple",
 			},
 		})


### PR DESCRIPTION
## Problem

Creating a Maple webhook from `/{org}/settings/integrations/maple` fails with:

\`\`\`
{
  \"_tag\": \"Die\",
  \"defect\": \"Avatar URL must point to an image\\n  at [\\\"avatarUrl\\\"]\"
}
\`\`\`

## Root cause

The \`channelWebhook.create\` RPC validates \`avatarUrl\` by issuing an HTTP HEAD against the URL and asserting the response \`Content-Type\` starts with \`image/\` ([packages/schema/src/avatar-url.ts:50](packages/schema/src/avatar-url.ts:50)). Brandfetch's CDN now redirects direct hits with \`HTTP 302 → docs.brandfetch.com/.../hotlinking\` (\`text/html\`), so the validator rejects the URL.

## Fix

Drop \`avatarUrl\` from the create payload in [maple-section.tsx](apps/web/src/components/channel-settings/maple-section.tsx). Two reasons this is safe:

1. The bot identity that actually appears on posted messages is resolved by \`IntegrationBotService.getOrCreateWebhookBotUser(\"maple\", ...)\`, which reads \`WEBHOOK_BOT_CONFIGS.maple\` for the avatar — unaffected by the create payload.
2. The webhook record's \`avatarUrl\` field is only used as a fallback in the channel integrations settings list (one usage in [routes/.../channels/$channelId/settings/integrations.tsx:262](apps/web/src/routes/_app/$orgSlug/channels/$channelId/settings/integrations.tsx:262)); the empty-state UI works fine.

## Notes

- The Brandfetch URL is still used for the inline icon in the section's own UI (rendered directly in `<img>`, no validation). If browsers also start blocking those, that's a separate UI fix.
- The same hotlinking issue likely affects the existing OpenStatus and Railway integrations on a fresh create — left out of scope here since the original report is Maple-specific. Worth a follow-up sweep.

## Test plan

- [ ] Navigate to `/{org}/settings/integrations/maple` → click Add Channel → pick a channel → Connect Maple. Expect: webhook created, copy-URL panel appears, no \"Avatar URL\" error in the toast or console.
- [ ] Post a Maple alert to the new webhook URL → confirm the message renders with the Maple bot identity (avatar + name from \`WEBHOOK_BOT_CONFIGS.maple\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)